### PR TITLE
Change "wsp chat" to "welcome"

### DIFF
--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -1,4 +1,4 @@
-<h1>wsp chat!</h1>
+<h1>Welcome!</h1>
 <p>Please sign in:</p>
 
 <%= form_tag "/auth/slack", method: :post, data: {turbo: false} do %>


### PR DESCRIPTION
I personally like it better the old way, but not everyone will understand the language/not as "professional"