### PR TITLE
Fix testimonial card sizing

### DIFF
--- a/app/assets/stylesheets/landing.scss
+++ b/app/assets/stylesheets/landing.scss
@@ -578,6 +578,9 @@ input {
       padding: 1em;
       width: 350px;
       border-radius: 16px;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
 
       h2 {
         background-color: var(--color-bg);
@@ -603,11 +606,14 @@ input {
         z-index: 3;
         margin-top: -2em;
         border-radius: 24px;
+        flex: 1 0 auto;
       }
 
       img {
         border-radius: 16px;
         width: 100%;
+        height: 180px;
+        object-fit: cover;
         box-shadow: var(--shadow);
       }
     }


### PR DESCRIPTION
Make image as well as card itself consistent in size. 

<img width="1288" height="676" alt="Screenshot 2025-11-17 at 10 19 51 PM" src="https://github.com/user-attachments/assets/ff7ca954-f5af-45bb-aca3-04d75a5d3d0f" />
