### PR TITLE
Turn off flipper memoization

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,3 +1,4 @@
 Rails.application.configure do
   config.flipper.preload = false
+  config.flipper.memoize = false
 end


### PR DESCRIPTION
For some reason this feature is causing flipper to preload it's keys on each request. Turning it off related to #169