### PR TITLE
Fix create project expanding when no projects

### DIFF
--- a/app/assets/stylesheets/pages/projects/_index.scss
+++ b/app/assets/stylesheets/pages/projects/_index.scss
@@ -40,6 +40,16 @@
   &__grid-item {
     width: 100%;
     height: 100%;
+
+    &:only-child {
+      max-width: 600px;
+    }
+
+    @media (max-width: 960px) {
+      &:only-child {
+        max-width: 100%;
+      }
+    }
   }
 
   &__create-card {


### PR DESCRIPTION
Made it not expand when no projects (it'll only expand when projects are created since that looks better on smaller screens).

<img width="1393" height="648" alt="Screenshot 2025-12-01 at 10 15 43 PM" src="https://github.com/user-attachments/assets/a1278ef8-cdef-4f65-830e-67f5b8206915" />
