### PR TITLE
Increase session lifetime

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,12 @@ module Battlemage
 
     # MissionControl::Jobs.base_controller_class = "Admin::ApplicationController"
     config.mission_control.jobs.http_basic_auth_enabled = false
+
+    # what do we want? sessions! when do we want em? now!
+    config.session_store :cookie_store,
+                         key: "_flavortown_session",
+                         expire_after: 2.months,
+                         secure: Rails.env.production?,
+                         httponly: true
   end
 end


### PR DESCRIPTION
Also gets rid of a Battlemage reference (Rails currently sets the session cookie name to `_battlemage_session`)