### PR TITLE
Add wget for coolify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips sqlite3 file && \
+    apt-get install --no-install-recommends -y curl wget libjemalloc2 libvips sqlite3 file && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment


### PR DESCRIPTION
This speeds up coolify healthchecks by a couple seconds because coolify will default to trying wget first before rolling to curl