### PR TITLE
Fix constant redefinition warnings in User::Role and User::TutorialStep

### DIFF
--- a/app/models/user/role.rb
+++ b/app/models/user/role.rb
@@ -3,7 +3,7 @@ class User
     include ActiveModel::Conversion
     extend ActiveModel::Naming
 
-    ALL = [
+    self::ALL = [
       new(0, :super_admin, "Can assign other users admin"),
       new(1, :admin, "Can do everything except assign or remove admin"),
       new(2, :fraud_dept, "Can issue negative payouts, cancel grants & shop orders, but not reject or ban users; access to Blazer; access to read-only admin User w/o PII"),
@@ -13,8 +13,8 @@ class User
       new(6, :helper, "Support team with read-only access to users (no PII), projects, and shop orders")
     ].freeze
 
-    SLUGGED = ALL.index_by(&:name).freeze
-    ALL_SLUGS = SLUGGED.keys.freeze
+    self::SLUGGED = self::ALL.index_by(&:name).freeze
+    self::ALL_SLUGS = self::SLUGGED.keys.freeze
 
     class << self
       def all = ALL

--- a/app/models/user/tutorial_step.rb
+++ b/app/models/user/tutorial_step.rb
@@ -15,7 +15,7 @@ class User
       def satisfied?(completed_steps) = completed_steps.include? slug
     end
 
-    ALL = [
+    self::ALL = [
       new(:first_login, "First login", "log into the platform for the first time!", "user", "/"),
       new(slug: :identity_verified,
           name: "Confirm your age",
@@ -52,8 +52,8 @@ class User
           ])
     ].freeze
 
-    SLUGGED = ALL.index_by(&:slug).freeze
-    ALL_SLUGS = SLUGGED.keys.freeze
+    self::SLUGGED = self::ALL.index_by(&:slug).freeze
+    self::ALL_SLUGS = self::SLUGGED.keys.freeze
 
     class << self
       def all = ALL


### PR DESCRIPTION
Use self:: prefix when defining constants inside Data.define blocks to ensure they are scoped to Role/TutorialStep rather than User class.

Amp-Thread-ID: https://ampcode.com/threads/T-019b2a27-27dc-754c-8ac7-e82b4e785ceb