### PR TITLE
Faster rsvp syncing by prioritizing unsynced records

### DIFF
--- a/app/jobs/airtable/base_sync_job.rb
+++ b/app/jobs/airtable/base_sync_job.rb
@@ -43,8 +43,24 @@ class Airtable::BaseSyncJob < ApplicationJob
     10
   end
 
+  def null_sync_limit
+    sync_limit
+  end
+
   def records_to_sync
-    @records_to_sync ||= records.order("#{synced_at_field} ASC NULLS FIRST").limit(sync_limit)
+    @records_to_sync ||= if null_sync_limit == sync_limit
+      records.order("#{synced_at_field} ASC NULLS FIRST").limit(sync_limit)
+    else
+      null_count = records.where(synced_at_field => nil).count
+      if null_count >= sync_limit
+        records.where(synced_at_field => nil).limit(null_sync_limit)
+      else
+        remaining = sync_limit - null_count
+        null_sql = records.where(synced_at_field => nil).to_sql
+        non_null_sql = records.where.not(synced_at_field => nil).order("#{synced_at_field} ASC").limit(remaining).to_sql
+        records.from("(#{null_sql} UNION ALL #{non_null_sql}) AS #{records.table_name}")
+      end
+    end
   end
 
   def table

--- a/app/jobs/airtable/rsvp_sync_job.rb
+++ b/app/jobs/airtable/rsvp_sync_job.rb
@@ -5,7 +5,7 @@ class Airtable::RsvpSyncJob < Airtable::BaseSyncJob
 
   def primary_key_field = "email"
 
-  def sync_limit = 100
+  def null_sync_limit = 100
 
   def field_mapping(rsvp)
     {


### PR DESCRIPTION
Before the airtable sync job would grab 10 records to upload every minute. This means that if 11 people rsvp'd 10 would get a confirmation email that minute and 1 would get an email the next minute.

After this change, if...

60 people rsvp all 60 will get synced that minute
5 rsvp, those 5 will get synced that minute & 5 old records will also sync (airtable batches 10 records at a time so we get this for free)

Now that flavortown is launched the rsvp specific logic doesn't matter as much, but I'm making this change because we'll want this ability in our airtable syncing logic!