### PR TITLE
Improve author activity line on post partials

### DIFF
--- a/app/components/post_component.html.erb
+++ b/app/components/post_component.html.erb
@@ -17,7 +17,7 @@
             <%= link_to "🤓", helpers.admin_user_magic_link_path(post.user), title: "Generate magic link", style: "text-decoration: none;" %>
           </span>
       <% end %>
-        <span style="opacity: 0.8;">worked on</span>
+        <span style="opacity: 0.8;"><%= author_activity %></span>
         <% if project_title.present? %>
           <%= link_to project_title, project_path(post.project) %>
         <% else %>

--- a/app/components/post_component.rb
+++ b/app/components/post_component.rb
@@ -49,6 +49,16 @@
       post.postable.is_a?(Post::FireEvent)
     end
 
+   def author_activity
+     if fire_event?
+       "sent their compliments to the chef of"
+     elsif ship_event?
+       "shipped"
+     else
+       "worked on"
+     end
+   end
+
    def attachments
      return [] unless post.postable.respond_to?(:attachments)
      post.postable.attachments


### PR DESCRIPTION
<img width="2230" height="1628" alt="Screenshot 2025-12-22 at 20 49 09" src="https://github.com/user-attachments/assets/b4cf377e-5025-4edd-a2c2-373e1b9fb944" />

This fixes the above screen shot ^, where a project by one user has a post titled 'other user worked on flavortown'. It should actually say "other user is marking this project as well done"