### PR TITLE
increase ratelimits for API

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -7,14 +7,14 @@ Rack::Attack.throttle("api/store_all/auth", limit: 5, period: 1.minute) do |req|
   end
 end
 
+# maximise project+devlog ratelimits
 Rack::Attack.throttle("api/projects_all/auth", limit: 50, period: 1.minute) do |req|
   if req.path == "/api/v1/projects" && req.params["query"].blank?
     req.env["HTTP_AUTHORIZATION"]
   end
 end
 
-# this one is fine to query more cause its with search
-Rack::Attack.throttle("api/projects_all_with_query/auth", limit: 40, period: 1.minute) do |req|
+Rack::Attack.throttle("api/projects_all_with_query/auth", limit: 50, period: 1.minute) do |req|
   if req.path == "/api/v1/projects" && req.params["query"].present?
     req.env["HTTP_AUTHORIZATION"]
   end
@@ -27,7 +27,7 @@ Rack::Attack.throttle("api/store/auth", limit: 30, period: 1.minute) do |req|
   end
 end
 
-Rack::Attack.throttle("api/projects/auth", limit: 30, period: 1.minute) do |req|
+Rack::Attack.throttle("api/projects/auth", limit: 50, period: 1.minute) do |req|
   if req.path.start_with?("/api/v1/projects/")
     req.env["HTTP_AUTHORIZATION"]
   end


### PR DESCRIPTION
The current ratelimit forces the DB to be scraped in a glaringly long 11 minutes. This is quite difficult to maneuver around especially when flavortown inevitably blows up and we get exponentially more projects and devlogs.

I have increased the ratelimits by enough to keep up with the future.