### PR TITLE
Simplify duration_seconds validation message

### DIFF
--- a/app/models/post/devlog.rb
+++ b/app/models/post/devlog.rb
@@ -63,7 +63,7 @@ class Post::Devlog < ApplicationRecord
   validates :duration_seconds,
             numericality: {
               greater_than_or_equal_to: 15.minutes,
-              message: "must be equal to or greater than 15 minutes"
+              message: "error, you must log at least 15 minutes to post a devlog"
             },
             allow_nil: true
   validates :body, presence: true, length: { maximum: 2_000 }, unless: -> { scrapbook_url.present? }


### PR DESCRIPTION
I just simplified the message so it doesn't say "Duration seconds must be equal to or greater than 900 seconds" but says "Duration seconds error, you must log at least 15 minutes to post a devlog"
Original message:
<img width="1440" height="900" alt="SCR-20251225-trpm" src="https://github.com/user-attachments/assets/f8220ef1-2e7f-4156-b514-8a7e1b52f5e6" />
