### PR TITLE
Fix apostrophe on start email input for consistent spacing

### DIFF
--- a/app/views/start/_step_name.html.erb
+++ b/app/views/start/_step_name.html.erb
@@ -32,7 +32,7 @@
         form: f,
         attribute: :email,
         color: :red,
-        subtitle: "We’ll never sell your information. We’ll only use it to send you updates and identify your account.",
+        subtitle: "We'll never sell your information. We'll only use it to send you updates and identify your account.",
         input_html: {
           value: @email,
           type: :email,


### PR DESCRIPTION
In the start flow, the email input box previously had inconsistent spacing with the display name input due to the usage of the apostrophe: `’` (right single quotation mark U+2019) versus `'` (apostrophe U+0027). This pr fixes the visual inconsistency.

<table>
<tr>
<td>Before
<img width="688" height="517" alt="image" src="https://github.com/user-attachments/assets/b049871e-4cfc-47b1-807d-9778512b62eb" /></td>
<td>After<img width="635" height="512" alt="image" src="https://github.com/user-attachments/assets/d56205ab-9120-4dd9-ba9e-25534f241cec" /></td>
</tr>
</table>

Note: This makes things consistent, but visually the input component may benefit from some spacing above the subtitle. Any thoughts on this?