### PR TITLE
fix: use limit instead of items for pagy

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -54,7 +54,7 @@ class Api::V1::ProjectsController < Api::BaseController
       )
     end
 
-    @pagy, @projects = pagy(projects, items: 100)
+    @pagy, @projects = pagy(projects, limit: 100)
   end
 
   def show

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -41,7 +41,7 @@ class Api::V1::UsersController < Api::BaseController
   }
 
   def index
-    @pagy, @users = pagy(User.includes(:projects).all, page: params[:page], items: 100)
+    @pagy, @users = pagy(User.includes(:projects).all, page: params[:page], limit: 100)
   end
 
   def show


### PR DESCRIPTION
This fixes the /projects and /users API endpoints to use 100 per page instead of the default 25. This error was caused by using the incorrect parameter "items" instead of "limit".
