### PR TITLE
Fix 404 error when user creates devlog with error and reloads

### DIFF
--- a/app/models/user/tutorial_step.rb
+++ b/app/models/user/tutorial_step.rb
@@ -26,7 +26,7 @@ class User
           name: "Post a devlog",
           description: "dev your log!",
           icon: "edit",
-          link: ->(_) { new_project_devlog_path(current_user.projects.first) },
+          link: ->(_) { project_devlogs_new_path(current_user.projects.first) },
           deps: [
             Dep[:create_project, "you need to create a project first!"]
           ]),

--- a/app/views/project/devlogs/loading.html.erb
+++ b/app/views/project/devlogs/loading.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Loading Devlog" %>
 
 <% content_for :head do %>
-  <meta http-equiv="refresh" content="3;url=<%= new_project_devlog_path(@project, retry: @retry_count + 1) %>">
+  <meta http-equiv="refresh" content="3;url=<%= project_devlogs_new_path(@project, retry: @retry_count + 1) %>">
 <% end %>
 
 <div class="projects-new">

--- a/app/views/project/devlogs/new.html.erb
+++ b/app/views/project/devlogs/new.html.erb
@@ -9,7 +9,7 @@
     </div>
 
     <%= form_with model: @devlog,
-                  url: project_devlogs_path(@project),
+                  url: project_devlogs_new_path(@project),
                   html: { multipart: true },
                   class: "projects-new__form",
                   local: true do |f| %>

--- a/app/views/projects/ship.html.erb
+++ b/app/views/projects/ship.html.erb
@@ -43,7 +43,7 @@
           <% end %>
         <% elsif @step == 4 %>
           <div class="projects-ship__step4-actions">
-            <%= link_to "Add Devlog", new_project_devlog_path(@project), class: "projects-ship__nav-btn projects-ship__nav-btn--prev" %>
+            <%= link_to "Add Devlog", project_devlogs_new_path(@project), class: "projects-ship__nav-btn projects-ship__nav-btn--prev" %>
             <% can_ship = @project.shippable? && @project.can_ship_again? %>
             <% if can_ship %>
               <button type="submit" form="ship-form" class="projects-ship__nav-btn projects-ship__nav-btn--submit">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -27,7 +27,7 @@
           <%= render ButtonComponent.new(
                 text: "Add Devlog",
                 color: :brown,
-                href: new_project_devlog_path(@project)
+                href: project_devlogs_new_path(@project)
               ) %>
         <% else %>
           <% if current_user.project_follows.exists?(project: @project) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,7 +233,8 @@ Rails.application.routes.draw do
   # Projects
   resources :projects, shallow: true do
     resources :memberships, only: [ :create, :destroy ], module: :project
-    resources :devlogs, only: [ :new, :create ], module: :project
+    get  "devlogs/new", to: "project/devlogs#new"
+    post "devlogs/new", to: "project/devlogs#create"
     resources :reports, only: [ :create ], module: :project
     member do
       get :ship


### PR DESCRIPTION
When a user creates a new devlog with an error and reloads the page, the route will not 404 anymore.
Current behavior:
* User submits the devlog creation form with an error, posts to the url /projects/:project_id/devlogs
* Server renders :new, but the url (without the /new) is changed. This leads to a 404 error on reload

Fixed behavior:
* User submits the devlog creation form with an error, posts to the url /projects/:project_id/devlogs/new
* Server renders :new, the url is preserved (with the /new) and there is no 404 error

The rationale for using the alias paths is that this allows the devlog text to be preserved on error, instead of clearing it with a redirect.

Video Demo
https://hackclub.enterprise.slack.com/files/U07B27ZHEJU/F0A5Q0FM2SX/screen_recording_2025-12-28_at_4.28.54___pm.mov

Resolves this Slack #flavortown-help ticket: [https://hackclub.slack.com/archives/C09MATKQM8C/p1766465463434559](https://hackclub.slack.com/archives/C09MATKQM8C/p1766465463434559)
Additional details to this decision available in the thread