### PR TITLE
fix(devlogs_controller): add view

### DIFF
--- a/app/views/api/v1/devlogs/index.jbuilder
+++ b/app/views/api/v1/devlogs/index.jbuilder
@@ -1,0 +1,10 @@
+json.devlogs @devlogs do |devlog|
+  json.extract! devlog, :id, :body, :comments_count, :duration_seconds, :likes_count, :scrapbook_url, :created_at, :updated_at
+end
+
+json.pagination do
+  json.current_page @pagy.page
+  json.total_pages @pagy.pages
+  json.total_count @pagy.count
+  json.next_page @pagy.next
+end

--- a/app/views/api/v1/devlogs/show.jbuilder
+++ b/app/views/api/v1/devlogs/show.jbuilder
@@ -1,0 +1,1 @@
+json.extract! @devlog, :id, :body, :comments_count, :duration_seconds, :likes_count, :scrapbook_url, :created_at, :updated_at


### PR DESCRIPTION
~~Since `Post::Devlog` is not bound to `Post`, joining `Post::Devlog` to `:post` is invalid and will return an empty response. This resolves that issue and will make the endpoint return to functioning like usual.~~

Added a proper view for the Devlogs endpoint so data can actually be serialized. My bad for not properly understanding this codebase enough lol.