### PR TITLE
Fix capitalization in prize labels

### DIFF
--- a/app/views/landing/sections/_previously_hosted.html.erb
+++ b/app/views/landing/sections/_previously_hosted.html.erb
@@ -92,11 +92,11 @@
           { value: "5044", label: "total prizes shipped to 79 countries", icon: image_path("landing/previously-hosted/prizes-shipped-badge.avif") }
         ],
         prizes: [
-          { image: image_path("landing/previously-hosted/macbook.avif"), label: "3 macbooks" },
+          { image: image_path("landing/previously-hosted/macbook.avif"), label: "3 MacBooks" },
           { image: image_path("landing/previously-hosted/ipad.avif"), label: "9 iPads" },
-          { image: image_path("landing/previously-hosted/pinecil.avif"), label: "104 pinecils" },
-          { image: image_path("landing/previously-hosted/factorio.avif"), label: "48 factorio copies" },
-          { image: image_path("landing/previously-hosted/flipper.avif"), label: "31 flippers" },
+          { image: image_path("landing/previously-hosted/pinecil.avif"), label: "104 Pinecils" },
+          { image: image_path("landing/previously-hosted/factorio.avif"), label: "48 Factorio copies" },
+          { image: image_path("landing/previously-hosted/flipper.avif"), label: "31 Flipper Zeros" },
           { label: "and more!" }
         ]
       },
@@ -108,11 +108,11 @@
           { value: "10,765", label: "total prizes shipped to 212 countries", icon: image_path("landing/previously-hosted/prizes-shipped-badge.avif") }
         ],
         prizes: [
-          { image: image_path("landing/previously-hosted/defcon.avif"), label: "2 tickets to defcon" },
-          { image: image_path("landing/previously-hosted/rpi_5.avif"), label: "327 rpi 5s" },
-          { image: image_path("landing/previously-hosted/ipad.avif"), label: "66 ipads" },
-          { image: image_path("landing/previously-hosted/mac_mini.avif"), label: "27 mac minis" },
-          { image: image_path("landing/previously-hosted/macbook.avif"), label: "11 macbooks" },
+          { image: image_path("landing/previously-hosted/defcon.avif"), label: "2 tickets to DEFCON" },
+          { image: image_path("landing/previously-hosted/rpi_5.avif"), label: "327 RPi 5s" },
+          { image: image_path("landing/previously-hosted/ipad.avif"), label: "66 iPads" },
+          { image: image_path("landing/previously-hosted/mac_mini.avif"), label: "27 Mac Minis" },
+          { image: image_path("landing/previously-hosted/macbook.avif"), label: "11 MacBooks" },
           { label: "and more!" }
         ]
       },
@@ -124,11 +124,11 @@
           { value: "6440", label: "total prizes shipped to 131 countries", icon: image_path("landing/previously-hosted/prizes-shipped-badge.avif") }
         ],
         prizes: [
-          { image: image_path("landing/previously-hosted/ipad.avif"), label: "120 ipads" },
-          { image: image_path("landing/previously-hosted/quest_3.avif"), label: "18 quest 3s" },
-          { image: image_path("landing/previously-hosted/a1_mini.avif"), label: "53 bambu labs" },
-          { image: image_path("landing/previously-hosted/thinkpad.avif"), label: "11 thinkpads" },
-          { image: image_path("landing/previously-hosted/framework.avif"), label: "14 frameworks" },
+          { image: image_path("landing/previously-hosted/ipad.avif"), label: "120 iPads" },
+          { image: image_path("landing/previously-hosted/quest_3.avif"), label: "18 Quest 3s" },
+          { image: image_path("landing/previously-hosted/a1_mini.avif"), label: "53 Bambu Lab A1 Minis" },
+          { image: image_path("landing/previously-hosted/thinkpad.avif"), label: "11 ThinkPads" },
+          { image: image_path("landing/previously-hosted/framework.avif"), label: "14 Frameworks" },
           { label: "and more!" }
         ]
       }


### PR DESCRIPTION
Updated labels for prizes to use correct capitalization. There was inconsistent capitalization for prize names. These follow the actual names of the prizes.