### PR TITLE
Update default meta description

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <meta name="twitter:creator" content="@hackclub">
     <meta property="og:locale" content="en_US">
     <meta property="og:site_name" content="Flavortown - Hack Club">
-    <meta name="description" content="Flavortown is Hack Club's fiscal sponsorship platform, empowering teen hackers to run their own nonprofit projects with transparent finances.">
+    <meta name="description" content="Build projects, earn cookies, get prizes. A Hack Club program for teen coders.">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="turbo-prefetch" content="false">


### PR DESCRIPTION
"Hack Club's fiscal sponsorship platform" isn't the best description 😭