### PR TITLE
Simplify explore/devlog lookup

### DIFF
--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -31,9 +31,9 @@ class ExploreController < ApplicationController
 
   def gallery
     scope = Project.includes(banner_attachment: :blob)
-                    .where(tutorial: false)
-                    .where.not(id: current_user&.projects&.pluck(:id) || [])
-                    .order(created_at: :desc)
+                   .where(tutorial: false)
+                   .excluding_member(current_user)
+                   .order(created_at: :desc)
 
     @pagy, @projects = pagy(scope)
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -47,6 +47,9 @@ class Project < ApplicationRecord
       "Minecraft Mods", "Hardware", "Android App", "iOS App", "Other"
     ].freeze
 
+    scope :excluding_member, ->(user) {
+        user ? where.not(id: user.projects) : all
+    }
     scope :fire, -> { where.not(marked_fire_at: nil) }
 
     belongs_to :marked_fire_by, class_name: "User", optional: true


### PR DESCRIPTION
Currently this page takes way more db hits to render then it should:
<img width="1160" height="90" alt="Screenshot 2025-12-30 at 18 04 12" src="https://github.com/user-attachments/assets/5dc590e4-248e-4c4c-90c7-efb65a012716" />

This pr should fix the n+1 in here & also help increase readability
