### PR TITLE
security fix preventing admins from superadminifying themselves

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -104,6 +104,11 @@ class Admin::UsersController < Admin::ApplicationController
         return redirect_to admin_user_path(@user)
       end
 
+      if role_name == "super_admin" && !current_user.super_admin?
+        flash[:alert] = "#{current_user.display_name} is not in the sudoers file."
+        return redirect_to admin_user_path(@user)
+      end
+
       @user.grant_role!(role_name)
 
       # Create explicit audit entry on User


### PR DESCRIPTION
There's no validation preventing admins from making themselves super admins, so with a modified form body an admin can become a super admin and wreak havoc. This fixes that issue.