### PR TITLE
Fix Bug Where You Can't See Days in Hours

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
     sign(num) + num.abs.to_s
   end
 
-  def format_seconds(seconds, include_days = true)
+  def format_seconds(seconds, include_days = false)
     return "0s" if seconds.nil? || seconds <= 0
 
     days = seconds / 86400


### PR DESCRIPTION
I think it this bit

/app/helper/application_helper.rb

```
def format_seconds(seconds, include_days: false)
    return "0s" if seconds.nil? || seconds <= 0

    days = seconds / 86400
    hours = (seconds % 86400) / 3600
    minutes = (seconds % 3600) / 60
    secs = seconds % 60

    parts = []
    parts << "#{days}d" if include_days && days > 0
    parts << "#{hours}h" if hours > 0 || (include_days && days > 0)
    parts << "#{minutes}m" if minutes > 0 || parts.any?
    parts << "#{secs}s" if parts.empty?

    parts.join(" ")
  end
```

I'm presuming include_days is false which means hours is put only until it reaches 24hr 
` parts << "#{hours}h" if hours > 0 || (include_days && days > 0) ` where it should be ` parts << "#{hours}h" if hours > 0 || (! include_days && days > 0) `

My Version is:

```
def format_seconds(seconds, include_days = false)
    return "0s" if seconds.nil? || seconds <= 0

    days = seconds / 86400
    hours = include_days ? (seconds % 86400) / 3600 : seconds / 3600
    
    minutes = (seconds % 3600) / 60
    secs = seconds % 60

    parts = []
    parts << "#{days}d" if include_days && days > 0
    parts << "#{hours}h" if hours > 0 || (!include_days && days > 0)
    parts << "#{minutes}m" if minutes > 0 || parts.any?
    
    parts << "#{secs}s" if parts.empty?

    parts.join(" ")
end
```