### PR TITLE
Remove free stickers announcement

### DIFF
--- a/app/views/kitchen/index.html.erb
+++ b/app/views/kitchen/index.html.erb
@@ -167,13 +167,6 @@
     </div>
   <% end %>
   <% end %>
-  <div class="kitchen-announcement">
-    <%= render AnnouncementComponent.new(
-      image: "flavortown_xmas_sticker.avif",
-      title: "More free stickers!",
-      description: "Ship before Jan 2nd, Friday (EST) and we'll send you this cool sticker!"
-    ) %>
-  </div>
   <div class="kitchen-stats">
     <%= render KitchenStatsComponent.new(user: current_user) %>
   </div>


### PR DESCRIPTION
This pr removes the announcement that shipping before Jan 2nd, Friday (EST) gets you a cool sticker, because the offer has expired.