### PR TITLE
Add seconds to default format_seconds

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,9 +37,9 @@ module ApplicationHelper
 
     parts = []
     parts << "#{days}d" if include_days && days > 0
-    parts << "#{hours}h" if hours > 0 || (include_days && days > 0)
+    parts << "#{hours}h" if hours > 0 || parts.any?
     parts << "#{minutes}m" if minutes > 0 || parts.any?
-    parts << "#{secs}s" if parts.empty?
+    parts << "#{secs}s" if secs > 0
 
     parts.join(" ")
   end


### PR DESCRIPTION
This doesn't hide the seconds by default. Before 1min 50sec would just be rendered as `1m`, now it shows as `1m 50s`