### PR TITLE
Fix missing blas dependencies in development

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -17,7 +17,9 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     vim \
     ffmpeg \
     imagemagick \
-    libffi-dev
+    libffi-dev \
+    libopenblas-dev \
+    liblapack-dev
 
 # Install Node.js and Yarn
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \


### PR DESCRIPTION
My bad! I'd installed this locally to my docker container without realizing it wasn't part of the dev build. This is from https://github.com/hackclub/flavortown/pull/794