### PR TITLE
Normalize capitalization in kitchen step descriptions

### DIFF
--- a/app/models/user/tutorial_step.rb
+++ b/app/models/user/tutorial_step.rb
@@ -16,15 +16,15 @@ class User
     end
 
     self::ALL = [
-      new(:first_login, "First login", "log into the platform for the first time!", "user", "/"),
+      new(:first_login, "First login", "Log into the platform for the first time!", "user", "/"),
       new(slug: :create_project,
           name: "Create your first project",
-          description: "what are you cooking?",
+          description: "What are you cooking?",
           icon: "fork_spoon_fill",
           link: ->(_) { new_project_path }),
       new(slug: :post_devlog,
           name: "Post a devlog",
-          description: "dev your log!",
+          description: "Dev your log!",
           icon: "edit",
           link: ->(_) { new_project_devlog_path(current_user.projects.first) },
           deps: [
@@ -48,7 +48,7 @@ class User
           link: ->(_) { "https://hackclub.slack.com/app_redirect?channel=USLACKBOT" }),
       new(slug: :free_stickers,
           name: "Get your stickers!",
-          description: "get your stickers!",
+          description: "Get your stickers!",
           icon: "sticker",
           link: ->(_) { shop_path },
           deps: [


### PR DESCRIPTION
This PR normalizes capitalization for user-facing step descriptions visible on the website's kitchen page.

No wording or behavior changes — capitalization only.