### PR TITLE
feat: add reject button for non-fulfilled orders, refresh verificatio…

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -430,3 +430,23 @@ body {
   display: flex;
   gap: 0.25rem;
 }
+
+/* Dialog / Modal */
+dialog {
+  border: none;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  max-width: 500px;
+  width: 90%;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  background: var(--color-tan-300);
+
+  &::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+
+  h2 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+  }
+}

--- a/app/models/shop_order.rb
+++ b/app/models/shop_order.rb
@@ -172,7 +172,7 @@ class ShopOrder < ApplicationRecord
     end
 
     event :mark_rejected do
-      transitions from: %i[pending awaiting_verification awaiting_periodical_fulfillment], to: :rejected
+      transitions from: %i[pending awaiting_verification awaiting_periodical_fulfillment on_hold], to: :rejected
       before do |rejection_reason|
         self.rejection_reason = rejection_reason
       end

--- a/app/views/admin/shop_orders/_reject_modal.html.erb
+++ b/app/views/admin/shop_orders/_reject_modal.html.erb
@@ -1,4 +1,4 @@
-<dialog id="reject-modal" style="border: none; border-radius: 8px; padding: 2rem; max-width: 500px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
+<dialog id="reject-modal">
   <h2>Reject Order #<%= order.id %></h2>
 
   <%= form_with url: reject_admin_shop_order_path(order), method: :post, local: true do |f| %>

--- a/app/views/admin/shop_orders/_stats.html.erb
+++ b/app/views/admin/shop_orders/_stats.html.erb
@@ -8,6 +8,12 @@
       Pending: <%= counts[:pending] %>
     <% end %>
 
+    <%= link_to admin_shop_orders_path(params.permit(:user_search, :shop_item_id, :date_from, :date_to, :sort, :view, :goob, :region).merge(status: 'awaiting_verification')),
+        class: "badge badge-awaiting_verification status-filter-link #{'active' if params[:status] == 'awaiting_verification'}",
+        style: "text-decoration: none;" do %>
+      Awaiting Verification: <%= counts[:awaiting_verification] %>
+    <% end %>
+
     <%= link_to admin_shop_orders_path(params.permit(:user_search, :shop_item_id, :date_from, :date_to, :sort, :view, :goob, :region).merge(status: 'awaiting_periodical_fulfillment')),
         class: "badge badge-awaiting_periodical_fulfillment status-filter-link #{'active' if params[:status] == 'awaiting_periodical_fulfillment'}",
         style: "text-decoration: none;" do %>

--- a/app/views/admin/shop_orders/show.html.erb
+++ b/app/views/admin/shop_orders/show.html.erb
@@ -267,11 +267,23 @@
         <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
         <button type="submit" class="btn-primary" style="width: 100%; padding: 0.2rem 0.4rem;" onclick="return confirm('Approve this order for fulfillment?')">✓ Approve</button>
       </form>
+    <% end %>
+
+    <%# Reject button for all non-fulfilled states %>
+    <% if %w[pending awaiting_verification awaiting_periodical_fulfillment on_hold].include?(@order.aasm_state) %>
       <button type="button" onclick="document.getElementById('reject-modal').showModal()" class="btn-danger" style="width: 100%; padding: 0.2rem 0.4rem;">✗ Reject</button>
       <%= render "reject_modal", order: @order %>
     <% end %>
 
-    <% if (@order.pending? || @order.awaiting_periodical_fulfillment?) && !current_user.fulfillment_person? %>
+    <%# Refresh verification button for awaiting_verification state %>
+    <% if @order.awaiting_verification? %>
+      <form method="post" action="<%= refresh_verification_admin_shop_order_path(@order) %>">
+        <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+        <button type="submit" class="btn-primary" style="width: 100%; padding: 0.2rem 0.4rem;" onclick="return confirm('Refresh verification status for this user?')">🔄 Refresh Verification</button>
+      </form>
+    <% end %>
+
+    <% if (@order.pending? || @order.awaiting_verification? || @order.awaiting_periodical_fulfillment?) && !current_user.fulfillment_person? %>
       <form method="post" action="<%= place_on_hold_admin_shop_order_path(@order) %>">
         <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
         <button type="submit" class="btn-secondary" style="width: 100%; padding: 0.2rem 0.4rem;" onclick="return confirm('Place this order on hold?')">⏸ Hold</button>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -104,6 +104,12 @@
                     title: "Sync Hackatime Data",
                     class: "btn-primary slim",
                     style: "font-size: 0.75rem; padding: 0.25rem 0.5rem;" %>
+      <%= button_to "🔄 Refresh Verification",
+                    refresh_verification_admin_user_path(@user),
+                    method: :post,
+                    title: "Refresh verification status from HCA",
+                    class: "btn-primary slim",
+                    data: { confirm: "Refresh verification status for #{@user.display_name}?" } %>
       <%= render 'role_toggle', user: @user, role_icon: '🕵️‍♀️', role_name: 'fraud_dept', disabled: !current_user&.admin? %>
       <%= render 'role_toggle', user: @user, role_icon: '📦', role_name: 'fulfillment_person', disabled: !current_user&.admin? %>
       <%= render 'role_toggle', user: @user, role_icon: '🚢', role_name: 'project_certifier', disabled: !current_user&.admin? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,6 +198,7 @@ Rails.application.routes.draw do
          post :shadow_ban
          post :unshadow_ban
          post :impersonate
+         post :refresh_verification
        end
        collection do
          post :stop_impersonating
@@ -227,6 +228,7 @@ Rails.application.routes.draw do
         post :mark_fulfilled
         post :update_internal_notes
         post :assign_user
+        post :refresh_verification
       end
     end
     resources :audit_logs, only: [ :index, :show ]


### PR DESCRIPTION
…n button

- Add reject button on all non-fulfilled order states (pending, awaiting_verification, awaiting_periodical_fulfillment, on_hold)
- Add refresh verification button on shop order and user admin pages
- Include awaiting_verification in shop_orders view and stats
- Update AASM to allow rejecting from on_hold state
- Add dialog styling to admin.scss
- Re-implement share votes to slack