### PR TITLE
Reconstruct missing migrations

### DIFF
--- a/app/models/post/ship_event.rb
+++ b/app/models/post/ship_event.rb
@@ -2,18 +2,28 @@
 #
 # Table name: post_ship_events
 #
-#  id                   :bigint           not null, primary key
-#  body                 :string
-#  certification_status :string           default("pending")
-#  feedback_reason      :text
-#  feedback_video_url   :string
-#  hours                :float
-#  multiplier           :float
-#  payout               :float
-#  synced_at            :datetime
-#  votes_count          :integer          default(0), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
+#  id                      :bigint           not null, primary key
+#  body                    :string
+#  certification_status    :string           default("pending")
+#  feedback_reason         :text
+#  feedback_video_url      :string
+#  hours                   :float
+#  multiplier              :float
+#  originality_median      :decimal(, )
+#  originality_percentile  :decimal(, )
+#  overall_percentile      :decimal(, )
+#  overall_score           :decimal(, )
+#  payout                  :float
+#  storytelling_median     :decimal(, )
+#  storytelling_percentile :decimal(, )
+#  synced_at               :datetime
+#  technical_median        :decimal(, )
+#  technical_percentile    :decimal(, )
+#  usability_median        :decimal(, )
+#  usability_percentile    :decimal(, )
+#  votes_count             :integer          default(0), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 class Post::ShipEvent < ApplicationRecord
   include Postable

--- a/db/migrate/20251224113734_add_voting_scores_to_post_ship_events.rb
+++ b/db/migrate/20251224113734_add_voting_scores_to_post_ship_events.rb
@@ -1,0 +1,15 @@
+# Recreated migration from production database
+# Original migration file was lost but existed in production schema_migrations table
+# See: https://hackclub.slack.com/archives/C09KCFWQSKE/p1769100073154269
+class AddVotingScoresToPostShipEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :post_ship_events, :originality_median, :numeric unless column_exists?(:post_ship_events, :originality_median)
+    add_column :post_ship_events, :originality_percentile, :numeric unless column_exists?(:post_ship_events, :originality_percentile)
+    add_column :post_ship_events, :technical_median, :numeric unless column_exists?(:post_ship_events, :technical_median)
+    add_column :post_ship_events, :technical_percentile, :numeric unless column_exists?(:post_ship_events, :technical_percentile)
+    add_column :post_ship_events, :usability_median, :numeric unless column_exists?(:post_ship_events, :usability_median)
+    add_column :post_ship_events, :usability_percentile, :numeric unless column_exists?(:post_ship_events, :usability_percentile)
+    add_column :post_ship_events, :storytelling_median, :numeric unless column_exists?(:post_ship_events, :storytelling_median)
+    add_column :post_ship_events, :storytelling_percentile, :numeric unless column_exists?(:post_ship_events, :storytelling_percentile)
+  end
+end

--- a/db/migrate/20251224113745_add_overall_scores_to_post_ship_events.rb
+++ b/db/migrate/20251224113745_add_overall_scores_to_post_ship_events.rb
@@ -1,0 +1,9 @@
+# Recreated migration from production database
+# Original migration file was lost but existed in production schema_migrations table
+# See: https://hackclub.slack.com/archives/C09KCFWQSKE/p1769100073154269
+class AddOverallScoresToPostShipEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :post_ship_events, :overall_score, :numeric unless column_exists?(:post_ship_events, :overall_score)
+    add_column :post_ship_events, :overall_percentile, :numeric unless column_exists?(:post_ship_events, :overall_percentile)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -312,9 +312,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_18_040252) do
     t.string "feedback_video_url"
     t.float "hours"
     t.float "multiplier"
+    t.decimal "originality_median"
+    t.decimal "originality_percentile"
+    t.decimal "overall_percentile"
+    t.decimal "overall_score"
     t.float "payout"
+    t.decimal "storytelling_median"
+    t.decimal "storytelling_percentile"
     t.datetime "synced_at"
+    t.decimal "technical_median"
+    t.decimal "technical_percentile"
     t.datetime "updated_at", null: false
+    t.decimal "usability_median"
+    t.decimal "usability_percentile"
     t.integer "votes_count", default: 0, null: false
   end
 

--- a/test/fixtures/post/ship_events.yml
+++ b/test/fixtures/post/ship_events.yml
@@ -4,18 +4,28 @@
 #
 # Table name: post_ship_events
 #
-#  id                   :bigint           not null, primary key
-#  body                 :string
-#  certification_status :string           default("pending")
-#  feedback_reason      :text
-#  feedback_video_url   :string
-#  hours                :float
-#  multiplier           :float
-#  payout               :float
-#  synced_at            :datetime
-#  votes_count          :integer          default(0), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
+#  id                      :bigint           not null, primary key
+#  body                    :string
+#  certification_status    :string           default("pending")
+#  feedback_reason         :text
+#  feedback_video_url      :string
+#  hours                   :float
+#  multiplier              :float
+#  originality_median      :decimal(, )
+#  originality_percentile  :decimal(, )
+#  overall_percentile      :decimal(, )
+#  overall_score           :decimal(, )
+#  payout                  :float
+#  storytelling_median     :decimal(, )
+#  storytelling_percentile :decimal(, )
+#  synced_at               :datetime
+#  technical_median        :decimal(, )
+#  technical_percentile    :decimal(, )
+#  usability_median        :decimal(, )
+#  usability_percentile    :decimal(, )
+#  votes_count             :integer          default(0), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 one:
   body: MyString

--- a/test/models/post/ship_event_test.rb
+++ b/test/models/post/ship_event_test.rb
@@ -2,18 +2,28 @@
 #
 # Table name: post_ship_events
 #
-#  id                   :bigint           not null, primary key
-#  body                 :string
-#  certification_status :string           default("pending")
-#  feedback_reason      :text
-#  feedback_video_url   :string
-#  hours                :float
-#  multiplier           :float
-#  payout               :float
-#  synced_at            :datetime
-#  votes_count          :integer          default(0), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
+#  id                      :bigint           not null, primary key
+#  body                    :string
+#  certification_status    :string           default("pending")
+#  feedback_reason         :text
+#  feedback_video_url      :string
+#  hours                   :float
+#  multiplier              :float
+#  originality_median      :decimal(, )
+#  originality_percentile  :decimal(, )
+#  overall_percentile      :decimal(, )
+#  overall_score           :decimal(, )
+#  payout                  :float
+#  storytelling_median     :decimal(, )
+#  storytelling_percentile :decimal(, )
+#  synced_at               :datetime
+#  technical_median        :decimal(, )
+#  technical_percentile    :decimal(, )
+#  usability_median        :decimal(, )
+#  usability_percentile    :decimal(, )
+#  votes_count             :integer          default(0), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 require "test_helper"
 


### PR DESCRIPTION
context in https://hackclub.slack.com/archives/C09KCFWQSKE/p1769105086122309?thread_ts=1769100073.154269&cid=C09KCFWQSKE

tl;dr these migrations were run on production but never checked into git. I'm reconstructing them by diffing the production schema vs a freshly generated local schema and assuming their names (using claude for migration name).

I don't know if we want these fields in prod, but this migration atleast gets our fields in sync in production so we can change/drop them later.