### PR TITLE
fix: fix adding multiple images to a devlog through api

### DIFF
--- a/app/controllers/api/v1/project_devlogs_controller.rb
+++ b/app/controllers/api/v1/project_devlogs_controller.rb
@@ -79,7 +79,6 @@ class Api::V1::ProjectDevlogsController < Api::BaseController
     ActiveRecord::Base.transaction do
       @devlog.save!(validate: false)
       attach_attachments!(@devlog, params[:attachments]) if params[:attachments].present?
-      @devlog.validate!
       @devlog.save!
       Post.create!(project: @project, user: current_api_user, postable: @devlog)
     end


### PR DESCRIPTION
fixes a wierd issue where attachments would only attach the last image if attaching before the devlog was saved