### PR TITLE
Make ShipCertWebhookJob retry indefinitely with exponential backoff

### DIFF
--- a/app/jobs/ship_cert_webhook_job.rb
+++ b/app/jobs/ship_cert_webhook_job.rb
@@ -1,8 +1,6 @@
 class ShipCertWebhookJob < ApplicationJob
   queue_as :default
-  retry_on StandardError, wait: :polynomially_longer, attempts: 5 do |job, error|
-    Rails.logger.error("[ShipCertWebhookJob] Failed after retries: #{error.message}")
-  end
+  retry_on StandardError, wait: :polynomially_longer, attempts: Float::INFINITY
 
   def perform(ship_event_id:, type: nil, force: false)
     return if !force && already_processed?(ship_event_id)


### PR DESCRIPTION
Ship Cert webhook jobs should never permanently fail. This changes the job to retry indefinitely with exponential backoff (`:polynomially_longer`) instead of giving up after 5 attempts and just logging an error.