### PR TITLE
Fix address field names

### DIFF
--- a/app/jobs/airtable/user_sync_job.rb
+++ b/app/jobs/airtable/user_sync_job.rb
@@ -35,10 +35,10 @@ class Airtable::UserSyncJob < Airtable::BaseSyncJob
 
     if address.present?
       fields.merge!(
-        "address_line_1" => address["address_line_1"],
-        "address_line_2" => address["address_line_2"],
+        "address_line_1" => address["line_1"],
+        "address_line_2" => address["line_2"],
         "address_city" => address["city"],
-        "address_state" => address["state_province"],
+        "address_state" => address["state"],
         "address_postal_code" => address["postal_code"],
         "address_country" => address["country"]
       )


### PR DESCRIPTION
This fixes the incorrectly named fields in https://github.com/hackclub/flavortown/pull/1104-- was looking at the wrong codebase while writing that.

for anyone looking for this in the future-- we get our address fields at https://auth.hackclub.com/docs/api