### PR TITLE
Fix fraud report counts handling

### DIFF
--- a/app/controllers/admin/super_mega_dashboard_controller.rb
+++ b/app/controllers/admin/super_mega_dashboard_controller.rb
@@ -19,9 +19,9 @@ module Admin
 
       report_counts = Project::Report.group(:status).count
       @fraud_reports = {
-        pending: report_counts["pending"] || 0,
-        reviewed: report_counts["reviewed"] || 0,
-        dismissed: report_counts["dismissed"] || 0,
+        pending: report_counts["pending"] || report_counts[0] || 0,
+        reviewed: report_counts["reviewed"] || report_counts[1] || 0,
+        dismissed: report_counts["dismissed"] || report_counts[2] || 0,
         new_today: Project::Report.where(created_at: today).count
       }
 

--- a/app/views/admin/fraud_dashboard/_leaderboard.html.erb
+++ b/app/views/admin/fraud_dashboard/_leaderboard.html.erb
@@ -5,5 +5,5 @@
     <% end %>
   </ul>
 <% else %>
-  <p class="fraud-note">No activity yet today</p>
+  <p class="fraud-note">No activity yet</p>
 <% end %>


### PR DESCRIPTION
Closes #1143

Update the handling of fraud report counts to ensure accurate retrieval from the database. Adjust the message displayed when there is no activity to be more concise.