### PR TITLE
Implement click-to-load functionality for images

### DIFF
--- a/app/assets/stylesheets/pages/projects/_readme.scss
+++ b/app/assets/stylesheets/pages/projects/_readme.scss
@@ -53,6 +53,37 @@
     margin: 1em 0;
   }
 
+  .click2load {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5em;
+    width: 100%;
+    min-height: 120px;
+    padding: 1.5em;
+    margin: 1em 0;
+    background-color: var(--color-bg-2);
+    border: 4px dashed var(--color-brown-300);
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease;
+
+    &:hover {
+      background-color: var(--color-brown-400);
+      border-color: var(--color-brown-400);
+    }
+
+    &__text {
+      font-family: var(--font-family-subtitle);
+      font-size: 1rem;
+      color: var(--color-brown-700);
+      font-weight: bold;
+    }
+  }
+
   pre {
     background-color: var(--color-brown-700);
     color: var(--color-bg);

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -134,3 +134,6 @@ application.register("stats-hover", StatsHoverController);
 
 import TooltipController from "./tooltip_controller";
 application.register("tooltip", TooltipController);
+
+import ReadmeImageController from "./readme_image_controller";
+application.register("readme-image", ReadmeImageController);

--- a/app/javascript/controllers/readme_image_controller.js
+++ b/app/javascript/controllers/readme_image_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static values = {
+    src: String,
+    alt: String,
+  };
+
+  load(event) {
+    event.preventDefault();
+    const img = document.createElement("img");
+    img.src = this.srcValue;
+    img.alt = this.altValue || "";
+    this.element.replaceWith(img);
+  }
+}

--- a/app/services/readme_html_rewriter.rb
+++ b/app/services/readme_html_rewriter.rb
@@ -13,7 +13,22 @@ class ReadmeHtmlRewriter
     fragment = Nokogiri::HTML::DocumentFragment.parse(html)
 
     fragment.css("img[src]").each do |img|
-      img["src"] = rewrite_url(img["src"], base: base)
+      rewritten_src = rewrite_url(img["src"], base: base)
+      alt_text = img["alt"].presence || "Image"
+
+      placeholder = Nokogiri::XML::Node.new("button", fragment.document)
+      placeholder["type"] = "button"
+      placeholder["class"] = "click2load"
+      placeholder["data-controller"] = "readme-image"
+      placeholder["data-readme-image-src-value"] = rewritten_src
+      placeholder["data-readme-image-alt-value"] = alt_text
+      placeholder["data-action"] = "click->readme-image#load"
+      placeholder.inner_html = <<~HTML
+        <span class="click2load__text">Click to load image</span>
+        <span class="click2load__text">Images are hidden to protect your privacy</span>
+      HTML
+
+      img.replace(placeholder)
     end
 
     fragment.css("a[href]").each do |a|


### PR DESCRIPTION
Closes #1201

Introduce a new button that replaces images with a placeholder, allowing users to click to load the image. This enhances privacy by hiding images until explicitly requested. The implementation includes a new Stimulus controller for handling the image loading process.