### PR TITLE
Exclude internal report endpoint from public docs

### DIFF
--- a/app/views/api/v1/docs/index.html.erb
+++ b/app/views/api/v1/docs/index.html.erb
@@ -74,6 +74,10 @@
         <% next %>
       <% end %>
 
+      <% if route.defaults[:controller] == "api/v1/external_reports" %>
+        <% next %>
+      <% end %>
+
       <div class="card">
         <div class="content">
           <h2><%= route.verb %> <%= route.path.spec.to_s.gsub("(.:format)", "") %></h2>


### PR DESCRIPTION
Closes #1228

Prevent the internal report endpoint from being displayed in the public documentation.