### PR TITLE
Allow fulfillment personnel to assign shop orders

### DIFF
--- a/app/controllers/admin/shop_orders_controller.rb
+++ b/app/controllers/admin/shop_orders_controller.rb
@@ -15,8 +15,8 @@ class Admin::ShopOrdersController < Admin::ApplicationController
       authorize :admin, :access_shop_orders?
     end
 
-    # Load fulfillment users for assignment dropdown (admins only, fulfillment view)
-    if current_user.admin? && @view == "fulfillment"
+    # Load fulfillment users for assignment dropdown (admins and fulfillment peeps, fulfillment view)
+    if (current_user.admin? || current_user.fulfillment_person?) && @view == "fulfillment"
       @fulfillment_users = User.where("'fulfillment_person' = ANY(granted_roles)").order(:display_name)
     end
 
@@ -145,8 +145,8 @@ class Admin::ShopOrdersController < Admin::ApplicationController
     @can_view_address = @order.can_view_address?(current_user)
     @is_digital_fulfillment_type = ShopOrder::DIGITAL_FULFILLMENT_TYPES.include?(@order.shop_item.type)
 
-    # Load fulfillment users for assignment (admins only)
-    if current_user.admin?
+    # Load fulfillment users for assignment (admins and fulfillment peeps)
+    if current_user.admin? || current_user.fulfillment_person?
       @fulfillment_users = User.where("'fulfillment_person' = ANY(granted_roles)").order(:display_name)
     end
 
@@ -337,7 +337,7 @@ class Admin::ShopOrdersController < Admin::ApplicationController
   end
 
   def assign_user
-    authorize :admin, :access_shop_orders?
+    authorize :admin, :assign_shop_order?
     @order = ShopOrder.find(params[:id])
     old_assigned = @order.assigned_to_user_id
 

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -47,6 +47,10 @@ class AdminPolicy < ApplicationPolicy
     user.admin? || user.fulfillment_person?
   end
 
+  def assign_shop_order?
+    user.admin? || user.fulfillment_person?
+  end
+
   def access_shop_orders?
     user.admin? || user.fraud_dept?
   end

--- a/app/views/admin/shop_orders/_table.html.erb
+++ b/app/views/admin/shop_orders/_table.html.erb
@@ -12,7 +12,7 @@
           <% if @view == 'fulfillment' %>
             <th>Region</th>
           <% end %>
-          <% if current_user.admin? && @view == 'fulfillment' %>
+          <% if (current_user.admin? || current_user.fulfillment_person?) && @view == 'fulfillment' %>
             <th>Assignee</th>
           <% end %>
           <th><%= @view == 'fulfillment' ? 'Hang Time' : 'Created' %></th>
@@ -60,7 +60,7 @@
               </td>
             <% end %>
 
-            <% if current_user.admin? && @view == 'fulfillment' %>
+            <% if (current_user.admin? || current_user.fulfillment_person?) && @view == 'fulfillment' %>
               <td>
                 <% if order.assigned_to_user.present? %>
                   <div style="display: flex; align-items: center; gap: 0.5rem;">

--- a/app/views/admin/shop_orders/show.html.erb
+++ b/app/views/admin/shop_orders/show.html.erb
@@ -192,7 +192,7 @@
 <div class="admin-section">
   <h2 class="admin-section__header">Fulfillment Information</h2>
   <div class="info-rows">
-    <% if current_user.admin? %>
+    <% if current_user.admin? || current_user.fulfillment_person? %>
       <div style="margin-bottom: 1rem;">
         <b>Assigned To:</b>
         <% if @order.assigned_to_user.present? %>


### PR DESCRIPTION
Enhance the assignment functionality by permitting fulfillment personnel, in addition to admins, to assign shop orders. This change updates the authorization checks and modifies the user interface to reflect the new permissions.