### PR TITLE
Update: Refactor default_url_host method to use APP_HOST only in ysws review job

### DIFF
--- a/app/jobs/ysws_review_sync_job.rb
+++ b/app/jobs/ysws_review_sync_job.rb
@@ -285,7 +285,7 @@ class YswsReviewSyncJob < ApplicationJob
   end
 
   def default_url_host
-      ENV["APP_HOST"]
+    ENV["APP_HOST"]
   end
 
   def project_exists_in_unified_db?(code_url)


### PR DESCRIPTION
Removed fallback options for default URL host in action mailer configuration.