### PR TITLE
Add shadow banned warning to admin pages

### DIFF
--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -12,6 +12,18 @@
   </div>
 <% end %>
 
+<% if @user.shadow_banned? %>
+  <div class="alert alert--danger" style="margin-bottom: 1rem;">
+    <strong>👻 This user is shadow banned</strong>
+    <% if @user.shadow_banned_reason.present? %>
+      <br>Reason: <%= @user.shadow_banned_reason %>
+    <% end %>
+    <% if @user.shadow_banned_at.present? %>
+      <br>Shadow banned at: <%= @user.shadow_banned_at.strftime("%Y-%m-%d %H:%M") %>
+    <% end %>
+  </div>
+<% end %>
+
 <div class="flex">
   <div class="card">
     <h2>basic info</h2>


### PR DESCRIPTION
Display a warning on admin pages for users who are shadow banned, including the reason and timestamp of the ban if available.