### PR TITLE
Implement PaperTrail for user bans and unbans

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -277,6 +277,17 @@ class Admin::UsersController < Admin::ApplicationController
       @user.ban!(reason: reason)
     end
 
+    PaperTrail::Version.create!(
+      item_type: "User",
+      item_id: @user.id,
+      event: "banned",
+      whodunnit: current_user.id.to_s,
+      object_changes: {
+        banned: [ false, true ],
+        banned_reason: [ nil, reason ]
+      }.to_json
+    )
+
     flash[:notice] = "#{@user.display_name} has been banned."
     redirect_to admin_user_path(@user)
   end
@@ -284,10 +295,22 @@ class Admin::UsersController < Admin::ApplicationController
   def unban
     authorize :admin, :ban_users?
     @user = User.find(params[:id])
+    old_reason = @user.banned_reason
 
     PaperTrail.request(whodunnit: current_user.id) do
       @user.unban!
     end
+
+    PaperTrail::Version.create!(
+      item_type: "User",
+      item_id: @user.id,
+      event: "unbanned",
+      whodunnit: current_user.id.to_s,
+      object_changes: {
+        banned: [ true, false ],
+        banned_reason: [ old_reason, nil ]
+      }.to_json
+    )
 
     flash[:notice] = "#{@user.display_name} has been unbanned."
     redirect_to admin_user_path(@user)
@@ -302,6 +325,17 @@ class Admin::UsersController < Admin::ApplicationController
       @user.shadow_ban!(reason: reason)
     end
 
+    PaperTrail::Version.create!(
+      item_type: "User",
+      item_id: @user.id,
+      event: "shadow_banned",
+      whodunnit: current_user.id.to_s,
+      object_changes: {
+        shadow_banned: [ false, true ],
+        shadow_banned_reason: [ nil, reason ]
+      }.to_json
+    )
+
     flash[:notice] = "#{@user.display_name} has been shadow banned."
     redirect_to admin_user_path(@user)
   end
@@ -309,10 +343,22 @@ class Admin::UsersController < Admin::ApplicationController
   def unshadow_ban
     authorize :admin, :ban_users?
     @user = User.find(params[:id])
+    old_reason = @user.shadow_banned_reason
 
     PaperTrail.request(whodunnit: current_user.id) do
       @user.unshadow_ban!
     end
+
+    PaperTrail::Version.create!(
+      item_type: "User",
+      item_id: @user.id,
+      event: "shadow_unbanned",
+      whodunnit: current_user.id.to_s,
+      object_changes: {
+        shadow_banned: [ true, false ],
+        shadow_banned_reason: [ old_reason, nil ]
+      }.to_json
+    )
 
     flash[:notice] = "#{@user.display_name} has been unshadow banned."
     redirect_to admin_user_path(@user)

--- a/app/views/admin/audit_logs/index.html.erb
+++ b/app/views/admin/audit_logs/index.html.erb
@@ -356,6 +356,30 @@
   color: #991b1b;
 }
 
+.badge-banned,
+.badge-shadow_banned {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.badge-unbanned,
+.badge-shadow_unbanned {
+  background-color: #d1fae5;
+  color: #065f46;
+}
+
+.badge-role_promoted,
+.badge-role_demoted {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.badge-impersonation_started,
+.badge-impersonation_stopped {
+  background-color: #e0e7ff;
+  color: #3730a3;
+}
+
 /* Searchable Select */
 .searchable-select-dropdown {
   display: none;


### PR DESCRIPTION
Add PaperTrail versioning for user ban, unban, shadow ban, and unshadow ban actions to track changes and reasons.