### PR TITLE
Improve OS detection logic in vote_matchmaker

### DIFF
--- a/app/services/vote_matchmaker.rb
+++ b/app/services/vote_matchmaker.rb
@@ -27,11 +27,17 @@ class VoteMatchmaker
 
   def detect_os(ua)
     return nil unless ua
-    return :android if ua.include?("Android")
-    return :ios if ua.include?("iPhone") || ua.include?("iPad")
-    return :windows if ua.include?("Windows")
-    return :mac if ua.include?("Macintosh")
-    return :linux if ua.include?("Linux")
+    s = ua.downcase
+
+    return :android if s.include?("android")
+    return :ios if s.include?("iphone") || s.include?("ipod") || s.include?("ipad")
+    if s.include?("macintosh") && (s.include?("mobile") || s.include?("cpu os") || s.include?("ipad"))
+      return :ios
+    end
+
+    return :windows if s.include?("windows")
+    return :mac if s.include?("macintosh")
+    return :linux if s.include?("linux")
     nil
   end
 


### PR DESCRIPTION
emm ipad's user-agent usually be a mac. I thought this change could improve ios dectetion

This pull request updates the `detect_os` method in `vote_matchmaker.rb` to improve and expand the detection of operating systems from user agent strings. The method now performs case-insensitive checks and more accurately distinguishes iOS devices, especially differentiating between Mac and iOS user agents.

Improvements to OS detection logic:

* User agent string checks are now case-insensitive by converting the string to lowercase before matching.
* iOS detection is expanded to include "ipod" in addition to "iphone" and "ipad", and adds extra logic to correctly identify iOS devices that might otherwise be misclassified as Macs (e.g., iPads running desktop-class browsers).
* The method maintains detection for Android, Windows, Mac, and Linux, but with improved reliability due to the lowercase conversion.