### PR TITLE
Fix pagy navigation error

### DIFF
--- a/app/views/admin/shop_orders/index.html.erb
+++ b/app/views/admin/shop_orders/index.html.erb
@@ -51,7 +51,7 @@
 <% elsif @shop_orders %>
   <%= render partial: "table", locals: { orders: @shop_orders } %>
   <% if @pagy %>
-    <%== pagy_nav(@pagy) %>
+    <%== @pagy.series_nav %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Resolve an issue with pagy navigation by updating the method used to render the navigation series.