### PR TITLE
Possible fix for incorrect info when shipping a project

### DIFF
--- a/app/views/projects/_project_form_fields.html.erb
+++ b/app/views/projects/_project_form_fields.html.erb
@@ -48,7 +48,7 @@
              data-action="change->project-form#toggleUpdatePrefix">
       <span class="projects-new__checkbox-label">This is an update</span>
     </label>
-    <div class="input__subtitle">Tick if updating a project previously submitted to Hack Club. Remember to describe what's new.</div>
+    <div class="input__subtitle">Tick if updating a project started before December 15th, 2025. Remember to describe what's new.</div>
   </div>
 
   <div class="input input--blue">


### PR DESCRIPTION
Still waiting for confirmation from AVD and others, but it seems that projects being updated should be when ft started, not if they were submitted to another Hack Club event. See the recent thread w/ me and Carlson in review-embassy for some context. Don't approve this until further confirmation, please. I'll put a comment or delete the PR when that is done.