### PR TITLE
fix: consistent error message for logged out users on /kitchen

### DIFF
--- a/app/controllers/kitchen_controller.rb
+++ b/app/controllers/kitchen_controller.rb
@@ -3,6 +3,8 @@ class KitchenController < ApplicationController
   before_action :require_login
 
   def index
+    authorize :kitchen, :index?
+
     identities = current_user.identities
 
     unless current_user.verification_verified? && current_user.ysws_eligible == true


### PR DESCRIPTION
SAFETY: not removing authorize :kitchen, :index? and the KitchenPolicy because of existing codebase practice and Pundit but they can be safely removed; their functionality has been deprecated by the new require_login which is used in other controllers already.

Show a nice error message to people who access /kitchen without login instead of `not allowed to KitchenPolicy#index? this Symbol`

Closes #1584