### PR TITLE
fix: total time on profile counting deleted projects

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -441,7 +441,7 @@ class User < ApplicationRecord
 
   def devlog_seconds_total
     Rails.cache.fetch("user/#{id}/devlog_seconds_total", expires_in: 10.minutes) do
-      devlog_postable_ids = Post.where(user_id: id, postable_type: "Post::Devlog")
+      devlog_postable_ids = Post.joins(:project).where(user_id: id, postable_type: "Post::Devlog")
                                 .select("postable_id::bigint")
       Post::Devlog.where(id: devlog_postable_ids).not_deleted.sum(:duration_seconds) || 0
     end
@@ -449,7 +449,7 @@ class User < ApplicationRecord
 
   def devlog_seconds_today
     Rails.cache.fetch("user/#{id}/devlog_seconds_today/#{Time.zone.today}", expires_in: 10.minutes) do
-      devlog_postable_ids = Post.where(user_id: id, postable_type: "Post::Devlog")
+      devlog_postable_ids = Post.joins(:project).where(user_id: id, postable_type: "Post::Devlog")
                                 .where(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day)
                                 .select("postable_id::bigint")
       Post::Devlog.where(id: devlog_postable_ids).not_deleted.sum(:duration_seconds) || 0


### PR DESCRIPTION
We should not count soft deleted projects in the total time on the profile field