### PR TITLE
fix(vote): Grammar on vote page (#1612)

### DIFF
--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -37,7 +37,7 @@ class Vote < ApplicationRecord
   MAX_SCORE = 9
 
   CATEGORIES = {
-    originality: "How distinct it is from common projects?",
+    originality: "How distinct is the project from common projects?",
     technicality: "How much effort did the baker put into the implementation?",
     usability: "Did you like using it? Could you use it at all?",
     storytelling: "How well does the baker document the development journey through devlogs, documentation, and READMEs?"


### PR DESCRIPTION
The message was originally "How distinct it is [sic] from common projects?"  The word order is wrong.

This PR changes "it is" to "is the project."  Using "is it" is another option, but I prefer "is the project" for clarity.

It should be grammatically correct now.

Closes #1612