### PR TITLE
Set hours for review sync to a fixed value of 24000

### DIFF
--- a/app/jobs/ysws_review_sync_job.rb
+++ b/app/jobs/ysws_review_sync_job.rb
@@ -99,7 +99,7 @@ class YswsReviewSyncJob < ApplicationJob
   end
 
   def perform
-    hours = YswsReviewService.hours_since_last_sync
+    hours = 24000 # YswsReviewService.hours_since_last_sync
     Rails.logger.info "[YswsReviewSyncJob] Fetching reviews from last #{hours} hours"
 
     reviews_response = YswsReviewService.fetch_reviews(hours: hours, status: "done")


### PR DESCRIPTION
Replaced dynamic hours calculation with a fixed value of 24000.