### PR TITLE
Fix webOS sidequest window drag while scrolling

### DIFF
--- a/app/javascript/controllers/xp_window_controller.js
+++ b/app/javascript/controllers/xp_window_controller.js
@@ -120,8 +120,7 @@ export default class extends Controller {
 
     if (this.isDragging) {
       this.handleDragMove(this.lastX, this.lastY);
-    }
-    else if (this.isResizing) {
+    } else if (this.isResizing) {
       this.handleResizeMove(this.lastX, this.lastY);
     }
   }
@@ -210,7 +209,8 @@ export default class extends Controller {
 
   handleResizeMove(clientX, clientY) {
     const newW = this.resizeStartW + (clientX - this.resizeStartX);
-    const newH = this.resizeStartH + (clientY - this.resizeStartY + window.scrollY);
+    const newH =
+      this.resizeStartH + (clientY - this.resizeStartY + window.scrollY);
     this.element.style.width = `${Math.max(200, newW)}px`;
     this.element.style.height = `${Math.max(100, newH)}px`;
   }
@@ -304,7 +304,7 @@ export default class extends Controller {
 
     if (this.hasErrorSoundTarget) {
       this.errorSoundTarget.currentTime = 0;
-      this.errorSoundTarget.play().catch(() => { });
+      this.errorSoundTarget.play().catch(() => {});
     }
   }
 


### PR DESCRIPTION
when attempting to drag the webOS sidequest window while not scrolled to the top of the document, or attempting to scroll while it is being dragged or resized, it will not drag/resize as expected. either it will be offset, or not react to the scrolling.

<img src="https://cdn.hackclub.com/019cd98e-3a87-72b4-98bd-3e5a0d98a283/showcasebuggywindowdrag.gif" width="550">

this PR simply adds support for both of these cases, i.e. accounts for window.scrollY.