### PR TITLE
fix: "1 devlogs" on various pages

### DIFF
--- a/app/components/vote_project_showcase_card_component.html.erb
+++ b/app/components/vote_project_showcase_card_component.html.erb
@@ -26,7 +26,7 @@
         </div>
         <div class="votes-new__project-card-stat">
           <%= helpers.inline_svg_tag "icons/paper.svg" %>
-          <span><%= project.devlogs_count %> devlogs</span>
+          <span><%= project.devlogs_count %> <%= "devlog".pluralize(project.devlogs_count) %></span>
         </div>
         <div class="votes-new__project-card-stat">
           <%= helpers.inline_svg_tag "icons/time.svg" %>

--- a/app/views/explore/_card.html.erb
+++ b/app/views/explore/_card.html.erb
@@ -31,7 +31,7 @@
     <div class="project-card__stats">
         <h5>
             <%= inline_svg_tag "icons/paper.svg", class: "project-card__stats-icon", aria: { hidden: true } %>
-            <%= project.devlogs_count %> devlogs
+            <%= project.devlogs_count %> <%= "devlog".pluralize(project.devlogs_count) %>
         </h5>
         <h5>
             <%= inline_svg_tag "icons/time.svg", class: "project-card__stats-icon", aria: { hidden: true } %>

--- a/app/views/projects/_card.html.erb
+++ b/app/views/projects/_card.html.erb
@@ -31,7 +31,7 @@
     <div class="project-card__stats">
         <h5>
             <%= inline_svg_tag "icons/paper.svg", class: "project-card__stats-icon", aria: { hidden: true } %>
-            <%= project.devlogs_count %> devlogs
+            <%= project.devlogs_count %> <%= "devlog".pluralize(project.devlogs_count) %>
         </h5>
         <h5>
             <%= inline_svg_tag "icons/time.svg", class: "project-card__stats-icon", aria: { hidden: true } %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -89,7 +89,7 @@
                             </div>
                             <div style="text-align: left;">
                                 <%= time_ago_in_words(project.created_at.to_date) %> ago •
-                                <%= project.devlogs_count %> devlogs
+                                <%= project.devlogs_count %> <%= "devlog".pluralize(project.devlogs_count) %>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
PR #1532 fixed the "1 devlogs" bug for a page, but many instances were left unfixed.  This PR was a result of a find-and-replace of `<%= project.devlogs_count %> devlogs` in my editor and **was not tested on vote <ins>or gallery</ins>** because I couldn't fill projects with <del>fraud</del> <ins>development</ins> hours.

This by no means fixes all incorrect plural words; it only fixes what my editor could find.

> [!NOTE]
> Please check vote and gallery before merging. I have not tested them for reasons described earlier.