### PR TITLE
Clubs Link Improvements

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -331,6 +331,13 @@
     &:hover {
       color: var(--color-brown-400);
     }
+
+    &--pending {
+      opacity: 0.5;
+      cursor: not-allowed;
+      text-decoration: none;
+      pointer-events: none;
+    }
   }
 }
 

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -43,11 +43,7 @@ class MyController < ApplicationController
   end
 
   def unlink_club
-    current_user.update!(
-      club_name: nil,
-      club_link: nil,
-      airtable_record_id: nil
-    )
+    current_user.update!(club_name: nil, club_link: nil)
     redirect_back fallback_location: root_path, notice: "Club unlinked"
   end
 

--- a/app/jobs/airtable/user_club_pull_job.rb
+++ b/app/jobs/airtable/user_club_pull_job.rb
@@ -23,7 +23,11 @@ class Airtable::UserClubPullJob < ApplicationJob
       club_link = record["club_link"]
       updates[:club_link] = club_link if user.club_link != club_link
 
-      user.update_columns(updates) if updates.any?
+      if updates.any?
+        newly_linked = user.club_name.blank? && updates[:club_name].present?
+        user.update_columns(updates)
+        user.dm_user("🏫 Your Hack Club (*#{updates[:club_name]}*) has been linked to your Flavortown account!") if newly_linked
+      end
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,6 +113,13 @@ class User < ApplicationRecord
 
   def has_role?(role_name) = roles.include?(role_name.to_sym)
 
+  FILLOUT_CLUB_FORM_URL = "https://forms.hackclub.com/t/24dbqdeN93us"
+
+  def fillout_club_url
+    return nil if airtable_record_id.blank?
+    "#{FILLOUT_CLUB_FORM_URL}?id=#{airtable_record_id}"
+  end
+
   def club_link_uri
     return nil if club_link.blank?
 

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -188,15 +188,16 @@
           🏫 Linked to <strong><%= current_user.club_name %></strong>
         </p>
         <%= button_to "Unlink club", my_club_path, method: :delete, class: "settings-form__club-unlink" %>
-      <% elsif current_user.valid_club_link? %>
-          <%= link_to "Link your club",
-                current_user.club_link,
-                target: "_blank",
-                rel: "noopener",
-                class: "settings-form__club-link" %>
-          <small class="settings-form__hint" style="margin-left: 0;">Connect your Flavortown account to your Hack Club.</small>
+      <% elsif current_user.airtable_record_id.present? %>
+        <%= link_to "Link your club",
+              current_user.fillout_club_url,
+              target: "_blank",
+              rel: "noopener",
+              class: "settings-form__club-link" %>
+        <small class="settings-form__hint" style="margin-left: 0;">Connect your Flavortown account to your Hack Club.</small>
       <% else %>
-        <small class="settings-form__hint" style="margin-left: 0;">Club linking will be available once your account syncs. Check back soon!</small>
+        <button class="settings-form__club-link settings-form__club-link--pending" disabled>Link your club</button>
+        <small class="settings-form__hint" style="margin-left: 0;">Sync pending — check back soon!</small>
       <% end %>
     </div>
 


### PR DESCRIPTION
Gets rid of the Waiting to Sync message bug, and also sends a Slack DM when a club is first linked via the daily sync