### PR TITLE
Prevent CI from firing twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@ name: CI
 on:
   pull_request:
   merge_group:
-  push:
-    branches:
-      - main
 
 env:
   BUNDLE_WITHOUT: development


### PR DESCRIPTION
The pull_request event covers pulls, and merge_group covers the merge queue (aka the main branch) so having push there too is causing duplicate runs