### PR TITLE
made it so it doesn't clear update description when editing

### DIFF
--- a/app/javascript/controllers/project_form_controller.js
+++ b/app/javascript/controllers/project_form_controller.js
@@ -55,7 +55,7 @@ export default class extends Controller {
     this.syncUpdateCheckbox();
 
     // made it sync the update description on load so people don't have to retype everything
-    this.syncUpdateDescriptionVisibility({clearWhenHidden: false});
+    this.syncUpdateDescriptionVisibility({ clearWhenHidden: false });
 
     if (
       this.hasRepoUrlTarget &&
@@ -407,7 +407,7 @@ export default class extends Controller {
     this.updateDeclarationTarget.checked = hasPrefix || hasUpdateDescription;
   }
 
-  syncUpdateDescriptionVisibility({clearWhenHidden = true} = {}) {
+  syncUpdateDescriptionVisibility({ clearWhenHidden = true } = {}) {
     if (!this.hasUpdateDescriptionContainerTarget) return;
 
     const isChecked =


### PR DESCRIPTION
There's people who have to retype their whole project update description, so this should fix it by setting clearWhenHidden to false, and only clears when you intentionally uncheck the box