### PR TITLE
fix: update redirection after order assignment to use redirect_back

### DIFF
--- a/app/controllers/admin/shop_orders_controller.rb
+++ b/app/controllers/admin/shop_orders_controller.rb
@@ -484,9 +484,9 @@ class Admin::ShopOrdersController < Admin::ApplicationController
         }
       )
 
-      redirect_to admin_shop_orders_path(view: "fulfillment"), notice: "Order assigned to #{assigned_user&.display_name || 'nobody'}"
+      redirect_back fallback_location: admin_shop_order_path(@order), notice: "Order assigned to #{assigned_user&.display_name || 'nobody'}"
     else
-      redirect_to admin_shop_orders_path(view: "fulfillment"), alert: "Failed to assign order"
+      redirect_back fallback_location: admin_shop_order_path(@order), alert: "Failed to assign order"
     end
   end
 


### PR DESCRIPTION
Now redirect_back will return you to whatever page you came from, the fulfillment list view, the individual order page, etc. If the referrer isn't available, it falls back to the order's show page.