### PR TITLE
Potential fix for code scanning alert no. 17: Stored cross-site scripting

### DIFF
--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -80,7 +80,7 @@
         <b>slack_id:</b>
         <% if @user.slack_id.present? %>
           <%= @user.slack_id %>
-          <%= link_to "go to slack", "https://hackclub.slack.com/team/#{@user.slack_id}", class: "btn-primary slim", target: "_blank" %>
+          <%= link_to "go to slack", "https://hackclub.slack.com/team/#{ERB::Util.url_encode(@user.slack_id)}", class: "btn-primary slim", target: "_blank" %>
         <% else %>
           <span style="color: #9ca3af;">N/A</span>
         <% end %>


### PR DESCRIPTION
Potential fix for [https://github.com/hackclub/flavortown/security/code-scanning/17](https://github.com/hackclub/flavortown/security/code-scanning/17)

In general, the right fix is to URL-encode untrusted values before interpolating them into URLs, so that any special characters they contain cannot break out of the intended URL structure or affect the surrounding HTML. In Rails, this can be done using `ERB::Util.url_encode` or the `CGI.escape` helper. We should avoid changing the visible behavior (still link to the same Slack profile for valid IDs) while ensuring any unusual characters are safely encoded.

The minimal, behavior-preserving change here is to wrap `@user.slack_id` in a URL-encoding helper when constructing the Slack URL in line 83. For example, change `"https://hackclub.slack.com/team/#{@user.slack_id}"` to `"https://hackclub.slack.com/team/#{ERB::Util.url_encode(@user.slack_id)}"`. This keeps the same base URL and keeps `slack_id` as the path component but ensures any characters outside the safe URL charset are percent-encoded. We only touch the snippet shown in `app/views/admin/users/show.html.erb`, and Rails’ standard helpers are already available in views, so we do not need additional imports in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
