### PR TITLE
fix (css): funnel label font too small

### DIFF
--- a/app/assets/stylesheets/pages/admin/_super_mega_dashboard.scss
+++ b/app/assets/stylesheets/pages/admin/_super_mega_dashboard.scss
@@ -743,7 +743,6 @@
   }
 
   .d3-funnel-label {
-    font-size: 10px;
     fill: var(--color-brown-700);
     white-space: nowrap;
   }


### PR DESCRIPTION
**Before:**
<img width="1312" height="788" alt="image" src="https://github.com/user-attachments/assets/bc10467b-72db-46c9-816a-246c96aeee5d" />



**After:**

<img width="1323" height="789" alt="image" src="https://github.com/user-attachments/assets/47ba1356-6ace-417a-9e5c-088e50676d9e" />
