### PR TITLE
Add McDonald's theme: golden arches color scheme and falling fries

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,6 +53,7 @@
 
 // Themes
 @use "themes/christmas";
+@use "themes/mcdonalds";
 
 // Pages
 @use "pages/projects/index";

--- a/app/assets/stylesheets/themes/_mcdonalds.scss
+++ b/app/assets/stylesheets/themes/_mcdonalds.scss
@@ -1,0 +1,100 @@
+// McDonald's Theme Styles
+// I'm lovin' it 🍟
+
+.mcdonalds-theme {
+  // Background - warm golden yellow tones
+  --color-bg: hsl(45, 100%, 93%);
+  --color-bg-2: hsl(42, 80%, 82%);
+
+  // Text - dark reds instead of browns
+  --color-text-header: hsl(3, 72%, 18%);
+  --color-text-body: hsl(3, 60%, 22%);
+  --color-text-muted: hsl(3, 40%, 38%);
+
+  // Red → McDonald's red tones
+  --color-red-500: hsl(3, 72%, 35%);
+  --color-red-450: hsl(3, 72%, 48%);
+  --color-red-400: hsl(3, 72%, 55%);
+  --color-red-300: hsl(3, 65%, 72%);
+
+  // Yellow → Golden Arches
+  --color-yellow-600: hsl(42, 85%, 30%);
+  --color-yellow-500: hsl(42, 95%, 42%);
+  --color-yellow-450: hsl(42, 100%, 53%);
+  --color-yellow-400: hsl(42, 100%, 59%);
+  --color-yellow-300: hsl(42, 100%, 73%);
+
+  // Blue → McDonald's dark red (sidebar uses these for blob/nav)
+  --color-blue-600: hsl(3, 72%, 18%);
+  --color-blue-500: hsl(3, 72%, 28%);
+  --color-blue-400: hsl(3, 72%, 40%);
+  --color-blue-300: hsl(3, 65%, 58%);
+
+  // Brown → deep red/burgundy
+  --color-brown-700: hsl(3, 60%, 15%);
+  --color-brown-600: hsl(3, 55%, 22%);
+  --color-brown-500: hsl(3, 50%, 28%);
+  --color-brown-400: hsl(3, 45%, 42%);
+  --color-brown-300: hsl(42, 55%, 62%);
+
+  // Tan → golden tones
+  --color-tan-400: hsl(42, 55%, 65%);
+  --color-tan-300: hsl(42, 65%, 78%);
+
+  // Utility colors
+  --color-brown-hover: hsla(3, 50%, 28%, 0.3);
+  --color-brown-hover-focus: hsla(3, 50%, 28%, 0.4);
+}
+
+// Falling fries container
+.falling-fries-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9999;
+  overflow: hidden;
+}
+
+.falling-fry {
+  position: absolute;
+  top: -40px;
+  font-size: 1.5rem;
+  line-height: 1;
+  animation: fry-fall linear infinite;
+  user-select: none;
+}
+
+@keyframes fry-fall {
+  0% {
+    transform: translateY(0) translateX(0) rotate(0deg);
+    opacity: 1;
+  }
+
+  25% {
+    transform: translateY(25vh) translateX(calc(var(--drift) * 0.5)) rotate(90deg);
+  }
+
+  50% {
+    transform: translateY(50vh) translateX(var(--drift)) rotate(180deg);
+  }
+
+  75% {
+    transform: translateY(75vh) translateX(calc(var(--drift) * 0.5)) rotate(270deg);
+  }
+
+  100% {
+    transform: translateY(110vh) translateX(0) rotate(360deg);
+    opacity: 0.6;
+  }
+}
+
+// Respect reduced motion preferences
+@media (prefers-reduced-motion: reduce) {
+  .falling-fry {
+    animation: none;
+    display: none;
+  }
+}

--- a/app/javascript/controllers/fries_controller.js
+++ b/app/javascript/controllers/fries_controller.js
@@ -1,0 +1,58 @@
+import { Controller } from "@hotwired/stimulus";
+
+const FRIES_EMOJIS = ["🍟", "🍔", "🍦", "🥤", "🍎"];
+
+export default class extends Controller {
+  connect() {
+    this.fries = [];
+    this.createFallingFries();
+  }
+
+  disconnect() {
+    if (this.friesContainer) {
+      this.friesContainer.remove();
+    }
+    this.fries = [];
+  }
+
+  createFallingFries() {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      return;
+    }
+
+    this.friesContainer = document.createElement("div");
+    this.friesContainer.className = "falling-fries-container";
+    this.friesContainer.setAttribute("aria-hidden", "true");
+    document.body.appendChild(this.friesContainer);
+
+    const friesCount = 30;
+    for (let i = 0; i < friesCount; i++) {
+      this.createFry();
+    }
+  }
+
+  createFry() {
+    const fry = document.createElement("div");
+    fry.className = "falling-fry";
+
+    const emoji = FRIES_EMOJIS[Math.floor(Math.random() * FRIES_EMOJIS.length)];
+    fry.textContent = emoji;
+
+    const startX = Math.random() * 100;
+    const duration = Math.random() * 12 + 8;
+    const delay = Math.random() * -25;
+    const drift = (Math.random() - 0.5) * 120;
+    const size = Math.random() * 0.8 + 0.8;
+
+    fry.style.cssText = `
+      left: ${startX}%;
+      font-size: ${size}rem;
+      animation-duration: ${duration}s;
+      animation-delay: ${delay}s;
+      --drift: ${drift}px;
+    `;
+
+    this.friesContainer.appendChild(fry);
+    this.fries.push(fry);
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -100,6 +100,9 @@ application.register("sidebar-pin", SidebarPinController);
 import SnowController from "./snow_controller";
 application.register("snow", SnowController);
 
+import FriesController from "./fries_controller";
+application.register("fries", FriesController);
+
 import StartDevlogController from "./start_devlog_controller";
 application.register("start-devlog", StartDevlogController);
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,7 +57,7 @@
     <%= Sentry.get_trace_propagation_meta.html_safe %> <%# erb_lint:disable ErbSafety %>
   </head>
 
-  <body class="<%= current_user.present? && !@hide_sidebar ? 'signed-in' : '' %> <%= @body_class %> <%= 'christmas-theme' if current_user && Flipper.enabled?(:christmas_theme, current_user) && current_user.special_effects_enabled %>" <%= 'data-controller="snow"'.html_safe if current_user && Flipper.enabled?(:christmas_theme, current_user) && current_user.special_effects_enabled %> <%= 'data-controller="stars"'.html_safe if controller_name == 'landing' && @landing_variant == 'challenger' %>>
+  <body class="<%= current_user.present? && !@hide_sidebar ? 'signed-in' : '' %> <%= @body_class %> mcdonalds-theme <%= 'christmas-theme' if current_user && Flipper.enabled?(:christmas_theme, current_user) && current_user.special_effects_enabled %>" data-controller="fries<%= ' snow' if current_user && Flipper.enabled?(:christmas_theme, current_user) && current_user.special_effects_enabled %><%= ' stars' if controller_name == 'landing' && @landing_variant == 'challenger' %>">
     <% if impersonating? %>
       <div class="impersonation-banner">
         <div class="impersonation-content">


### PR DESCRIPTION
## Summary

- Overrides the site-wide CSS color palette to McDonald's red and golden yellow, replacing the warm cream/blue/brown defaults
- Replaces sidebar blue tones with dark McDonald's red for a fully immersive theme
- Adds a falling fries/burgers emoji rain animation via a new `FriesController` Stimulus controller (similar to the existing Christmas snow effect)
- Applied globally via `mcdonalds-theme` CSS class always present on `<body>`

I'm lovin' it 🍟
