### PR TITLE
fix(ship): prevent posts with null postable_id when shipping

### DIFF
--- a/app/controllers/projects/ships_controller.rb
+++ b/app/controllers/projects/ships_controller.rb
@@ -21,10 +21,11 @@ class Projects::ShipsController < ApplicationController
     @project.with_lock do
       apply_space_theme_for_sidequest!(selected_sidequest)
       @project.submit_for_review!
-      @post = @project.posts.create!(user: current_user, postable: Post::ShipEvent.new(
+      ship_event = Post::ShipEvent.create!(
         body: params[:ship_update].to_s.strip,
         review_instructions: params[:review_instructions].to_s.strip.presence
-      ))
+      )
+      @post = @project.posts.create!(user: current_user, postable: ship_event)
       create_sidequest_entries!(selected_sidequest)
     end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -237,12 +237,18 @@ class ProjectsController < ApplicationController
     end
 
     PaperTrail.request(whodunnit: current_user.id) do
-      fire_event = Post::FireEvent.new(
+      fire_event = Post::FireEvent.create(
         body: "🔥 #{current_user.display_name} marked your project as well cooked! As a prize for your nicely cooked project, look out for a bonus prize in the mail :)"
       )
-      post = @project.posts.build(user: current_user, postable: fire_event)
 
-      if post.save
+      unless fire_event.persisted?
+        render json: { message: fire_event.errors.full_messages.to_sentence.presence || "Failed to mark project as 🔥" }, status: :unprocessable_entity
+        next
+      end
+
+      post = @project.posts.create(user: current_user, postable: fire_event)
+
+      if post.persisted?
         @project.mark_fire!(current_user)
 
         PaperTrail::Version.create!(

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -34,6 +34,8 @@ class Post < ApplicationRecord
 
     delegated_type :postable, types: Postable.types
 
+    validates :postable_id, presence: true, if: :postable_type?
+
     after_commit :invalidate_project_time_cache, on: [ :create, :destroy ]
     after_commit :increment_devlogs_count, on: :create
     after_commit :decrement_devlogs_count, on: :destroy


### PR DESCRIPTION
Previously we could persist Post rows with `postable_type: Post::ShipEvent` and a null `postable_id` when ShipEvent validation failed. Those posts didn't show as real ships but still acted as “previous ship” boundaries, so hours between ships were wrong. This PR saves the ShipEvent first (and validates postable_id when a type is set) so we never commit an orphan post again.
