### PR TITLE
fix(super-mega): exclude contractor payments from dollars per hour calc

### DIFF
--- a/app/assets/stylesheets/pages/admin/_super_mega_dashboard.scss
+++ b/app/assets/stylesheets/pages/admin/_super_mega_dashboard.scss
@@ -45,7 +45,6 @@
     background: var(--color-tan-300);
     border-radius: 12px;
     padding: 1rem;
-    border: 1px solid var(--color-brown-700);
     overflow: hidden;
   }
 

--- a/app/controllers/concerns/admin/super_mega_dashboard/misc_stats.rb
+++ b/app/controllers/concerns/admin/super_mega_dashboard/misc_stats.rb
@@ -29,7 +29,11 @@ module Admin
           cookie_utilization_percentage = ((used_cookies.to_f / total_distributed_cookies) * 100).round(2)
 
           total_approved_ysws_db_hours = fetch_approved_ysws_db_hours
-          hcb_expenses = get_hcb_expenses
+
+          transaction_data = build_transaction_data
+          hcb_expenses = transaction_data[:total_expenses]
+          contractor_expenses = transaction_data[:contractor_expenses]
+
           if total_approved_ysws_db_hours > 0
             dollars_per_hour = (total_distributed_cookies / 5) / total_approved_ysws_db_hours
             expenses_dollars_per_hour = hcb_expenses / total_approved_ysws_db_hours
@@ -48,7 +52,8 @@ module Admin
             },
             cookie_utilization_percentage: cookie_utilization_percentage,
             dollars_per_hour: dollars_per_hour,
-            expenses_dollars_per_hour: expenses_dollars_per_hour
+            expenses_dollars_per_hour: expenses_dollars_per_hour,
+            contractor_expenses: contractor_expenses
           }
         end
         @payouts_cap = cached_data&.dig(:payouts_cap) || 0
@@ -57,6 +62,15 @@ module Admin
         @dollars_per_hour = cached_data&.dig(:dollars_per_hour) || 0
         @expenses_dollars_per_hour = cached_data&.dig(:expenses_dollars_per_hour) || 0
         @cookie_utilization_percentage = cached_data&.dig(:cookie_utilization_percentage) || 0
+        @contractor_expenses = cached_data&.dig(:contractor_expenses) || 0
+      rescue StandardError => e
+        Rails.logger.error("[SuperMegaDashboard] Error in load_payouts_stats: #{e.class} - #{e.message}")
+        @payouts_cap = 0
+        @payouts = { created: 0, destroyed: 0, txns: 0, volume: 0 }
+        @dollars_per_hour = 0
+        @expenses_dollars_per_hour = 0
+        @cookie_utilization_percentage = 0
+        @contractor_expenses = 0
       end
 
       def load_voting_stats
@@ -415,17 +429,40 @@ module Admin
         0
       end
 
-      def get_hcb_expenses
-        response = Faraday.get("https://hcb.hackclub.com/api/v3/organizations/flavortown")
-        if response.success?
+      def build_transaction_data
+        total_expenses = 0
+        contractor_expenses = 0
+        current_page = 1
+
+        loop do
+          response = Faraday.get("https://hcb.hackclub.com/api/v3/organizations/flavortown/transactions", { page: current_page })
+          break unless response.success?
+
           data = JSON.parse(response.body)
-          total_raised = data.dig("balances", "total_raised") || 0
-          balance = data.dig("balances", "balance_cents") || 0
-          total_expenses = (total_raised - balance).to_f / 100
-          total_expenses
-        else
-          0
+          break if data.empty?
+
+          data.each do |txn|
+            amount = txn["amount_cents"].to_i
+            next unless amount < 0
+
+            has_contributor_tag = txn["tags"]&.any? do |tag|
+              tag["label"] == "Contributor"
+            end
+
+            if has_contributor_tag
+              contractor_expenses += amount.abs
+            else
+              total_expenses += amount.abs
+            end
+          end
+
+          current_page += 1
         end
+
+        {
+          total_expenses: total_expenses / 100,
+          contractor_expenses: contractor_expenses / 100
+        }
       end
 
       def balance_color_class(balance_cents)

--- a/app/views/admin/super_mega_dashboard/sections/_payouts.html.erb
+++ b/app/views/admin/super_mega_dashboard/sections/_payouts.html.erb
@@ -66,6 +66,16 @@
         </div>
       </div>
     </div>
+
+    <div class="super-mega-dashboard__card">
+      <h3>Contractor Payments</h3>
+      <div class="super-mega-dashboard__stats">
+        <div class="super-mega-dashboard__stat">
+          <span class="super-mega-dashboard__stat--value"><%= @contractor_expenses.round(2) %></span>
+          <span class="super-mega-dashboard__stat--label">$</span>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
Uses the paginated HCB V3 /transactions API (ty Amber for tagging each expense). Also shows the sum total of contractor expenses but I'll remove that later since it doesn't look very helpful. 