### PR TITLE
feat(super-mega): add most common shop suggestions to fulfillment dash

### DIFF
--- a/app/assets/stylesheets/pages/admin/_super_mega_dashboard.scss
+++ b/app/assets/stylesheets/pages/admin/_super_mega_dashboard.scss
@@ -2168,6 +2168,33 @@
   }
 }
 
+.smd-common-shop-suggestions {
+  margin-top: 1.5rem;
+
+  &__title {
+    font-size: 1.5rem !important;
+    margin-bottom: 0.5rem !important;
+    color: var(--color-brown-500);
+    text-align: left;
+  }
+
+  &__list {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    overflow-y: scroll;
+  }
+
+  &__suggestion {
+    border-radius: 0.5rem;
+    padding: 0.75rem 1rem;
+    font-size: 1.25rem;
+    color: var(--color-brown-700);
+    background-color: white;
+    text-align: center;
+  }
+}
+
 .show-and-tell-winner-link {
   font-size: 1.75rem;
   padding: 0.5rem;

--- a/app/controllers/admin/super_mega_dashboard_controller.rb
+++ b/app/controllers/admin/super_mega_dashboard_controller.rb
@@ -19,6 +19,7 @@ module Admin
       super_mega_fulfillment
       super_mega_fulfillment_trend
       super_mega_order_states_trend
+      shop_suggestion_llm_results
       super_mega_support
       super_mega_support_vibes
       super_mega_support_graph

--- a/app/controllers/concerns/admin/super_mega_dashboard/fulfillment_stats.rb
+++ b/app/controllers/concerns/admin/super_mega_dashboard/fulfillment_stats.rb
@@ -47,6 +47,7 @@ module Admin
         @fulfillment_trend_data = build_fulfillment_trend_data
         @order_states_trend_data = build_order_states_trend_data
         @recent_new_items = ShopItem.recently_added.enabled.includes(image_attachment: :blob).limit(12)
+        @common_shop_suggestions = get_shop_suggestions
       rescue StandardError => e
         Rails.logger.warn("[SuperMegaDashboard] Fulfillment stats failed (#{e.class}): #{e.message}")
 
@@ -62,6 +63,7 @@ module Admin
         @fulfillment_trend_data = nil
         @order_states_trend_data = nil
         @recent_new_items = []
+        @common_shop_suggestions = []
       end
 
       def build_fulfillment_trend_data
@@ -128,6 +130,63 @@ module Admin
         end
 
         { awaiting: awaiting, fulfilled: fulfilled }
+      end
+
+      def get_shop_suggestions
+        cache_key = "shop_suggestion_llm_results"
+        cached = Rails.cache.read(cache_key)
+        last_called = cached&.dig(:last_called)
+
+        return cached[:result] if last_called.present? && last_called >= 24.hours.ago
+
+        items = ShopSuggestion.order(created_at: :desc).limit(500).pluck(:item)
+        llm_result = get_common_suggestions(items)
+
+        if llm_result.present?
+          Rails.cache.write(cache_key, { result: llm_result, last_called: Time.current })
+          llm_result
+        else
+          cached&.dig(:result) || []
+        end
+      end
+
+      def get_common_suggestions(items)
+        return [] if items.blank?
+
+        prompt = <<~PROMPT
+          Analyze the following suggestions for a hacker shop and identify 8-10 of the most commonly requested items or themes.
+
+          INPUT DATA:
+          #{JSON.generate(items)}
+
+          OUTPUT INSTRUCTIONS:
+          Return only valid JSON with no markdown formatting or code blocks, following this exact schema:
+          [suggestion1, suggestion2, ...]
+        PROMPT
+
+        llm_response = Faraday.post("https://openrouter.ai/api/v1/chat/completions") do |req|
+          req.headers["Authorization"] = "Bearer #{ENV['OPENROUTER_API_KEY']}"
+          req.headers["Content-Type"] = "application/json"
+          req.body = {
+            model: "x-ai/grok-4.1-fast",
+            messages: [
+              { role: "user", content: prompt }
+            ]
+          }.to_json
+        end
+
+        unless llm_response.success?
+          return []
+        end
+
+        llm_body = JSON.parse(llm_response.body)
+        content = llm_body.dig("choices", 0, "message", "content")
+        cleaned_content = content.gsub(/^```json\s*|```\s*$/, "")
+        data = JSON.parse(cleaned_content)
+
+        data
+      rescue JSON::ParserError => e
+        []
       end
     end
   end

--- a/app/views/admin/super_mega_dashboard/sections/_fulfillment.html.erb
+++ b/app/views/admin/super_mega_dashboard/sections/_fulfillment.html.erb
@@ -422,4 +422,15 @@
           });
         </script>
       <% end %>
+
+      <% if @common_shop_suggestions.present? %>
+        <div class="smd-common-shop-suggestions">
+          <h3 class="smd-common-shop-suggestions__title">Common Shop Suggestions</h3>
+          <div class="smd-common-shop-suggestions__list">
+            <% @common_shop_suggestions.each do |item| %>
+              <div class="smd-common-shop-suggestions__suggestion"><%= item %></div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
     </div>


### PR DESCRIPTION
Uses an LLM to analyze the last 500 shop suggestions to give a list of 8-10 of the most common ones. Results stored in rails cache and refreshed every 24 hours (or manually if needed). 