### PR TITLE
feat(explore): added well-cooked filter for project gallery

### DIFF
--- a/app/assets/stylesheets/pages/explore/_index.scss
+++ b/app/assets/stylesheets/pages/explore/_index.scss
@@ -66,6 +66,10 @@
     }
 
     &--sort {
+      display: flex;
+      align-items: center;
+      gap: 0.5em;
+
       .dropdown {
         &__label {
           display: none;
@@ -93,6 +97,49 @@
         display: block;
       }
     }
+  }
+
+  &__cooked-filter {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    font-size: 1rem;
+    color: var(--color-brown-500);
+    text-decoration: none;
+    padding: 0.25em 0.6em;
+    border: 0.15em solid var(--color-brown-400);
+    border-radius: 8px;
+    white-space: nowrap;
+
+    &:hover {
+      border-color: var(--color-brown-600);
+      color: var(--color-brown-700);
+    }
+
+    &.active {
+      background-color: var(--color-brown-500);
+      color: var(--color-bg);
+      border-color: var(--color-brown-500);
+
+      &:hover {
+        background-color: var(--color-brown-700);
+        border-color: var(--color-brown-700);
+        color: var(--color-bg);
+      }
+    }
+  }
+
+  &__cooked-filter-checkbox {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1em;
+    height: 1em;
+    border: 0.12em solid currentColor;
+    border-radius: 3px;
+    font-size: 0.8em;
+    line-height: 1;
+    flex-shrink: 0;
   }
 
   &__nav-component {

--- a/app/assets/stylesheets/pages/explore/_index.scss
+++ b/app/assets/stylesheets/pages/explore/_index.scss
@@ -66,10 +66,6 @@
     }
 
     &--sort {
-      display: flex;
-      align-items: center;
-      gap: 0.5em;
-
       .dropdown {
         &__label {
           display: none;
@@ -97,49 +93,6 @@
         display: block;
       }
     }
-  }
-
-  &__cooked-filter {
-    display: flex;
-    align-items: center;
-    gap: 0.4em;
-    font-size: 1rem;
-    color: var(--color-brown-500);
-    text-decoration: none;
-    padding: 0.25em 0.6em;
-    border: 0.15em solid var(--color-brown-400);
-    border-radius: 8px;
-    white-space: nowrap;
-
-    &:hover {
-      border-color: var(--color-brown-600);
-      color: var(--color-brown-700);
-    }
-
-    &.active {
-      background-color: var(--color-brown-500);
-      color: var(--color-bg);
-      border-color: var(--color-brown-500);
-
-      &:hover {
-        background-color: var(--color-brown-700);
-        border-color: var(--color-brown-700);
-        color: var(--color-bg);
-      }
-    }
-  }
-
-  &__cooked-filter-checkbox {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1em;
-    height: 1em;
-    border: 0.12em solid currentColor;
-    border-radius: 3px;
-    font-size: 0.8em;
-    line-height: 1;
-    flex-shrink: 0;
   }
 
   &__nav-component {

--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -45,7 +45,7 @@ class ExploreController < ApplicationController
                    .excluding_member(current_user)
                    .excluding_shadow_banned
 
-    scope = scope.fire if params[:filter] == "cooked"
+    scope = scope.fire if params[:sort] == "well-cooked"
 
     if params[:sort] == "following" && current_user
       scope = scope.where(id: current_user.project_follows.select(:project_id)).order(created_at: :desc)

--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -45,6 +45,8 @@ class ExploreController < ApplicationController
                    .excluding_member(current_user)
                    .excluding_shadow_banned
 
+    scope = scope.fire if params[:filter] == "cooked"
+
     if params[:sort] == "following" && current_user
       scope = scope.where(id: current_user.project_follows.select(:project_id)).order(created_at: :desc)
     elsif params[:sort] == "top"

--- a/app/views/explore/_explore_nav.html.erb
+++ b/app/views/explore/_explore_nav.html.erb
@@ -39,45 +39,38 @@
   <div class="explore__nav--sort">
     <%
       base_path = request.path
-      cooked_active = params[:filter] == "cooked"
-      cooked_suffix = cooked_active ? "&filter=cooked" : ""
-
       sort_options = [
-        { label: "Newest", value: "#{base_path}?sort=newest#{cooked_suffix}" },
-        { label: "Top", value: "#{base_path}?sort=top#{cooked_suffix}" }
+        { label: "Newest", value: "#{base_path}?sort=newest" },
+        { label: "Top", value: "#{base_path}?sort=top" }
       ]
 
       if current_user
-        sort_options << { label: "Following", value: "#{base_path}?sort=following#{cooked_suffix}" }
+        sort_options << { label: "Following", value: "#{base_path}?sort=following" }
+      end
+
+      if current_page?(explore_gallery_path)
+        sort_options << { label: "Well Cooked", value: "#{base_path}?sort=well-cooked" }
       end
 
       selected_label = case params[:sort]
-                       when "top" then "Top"
-                       when "following" then "Following"
-                       else "Newest"
+                         when "top" then "Top"
+                         when "following" then "Following"
+                         when "well-cooked" then "Well Cooked"
+                         else "Newest"
                        end
 
       sort_color = case selected_label
-                   when "Top" then :red
-                   when "Following" then :blue
-                   else :green
+                     when "Top" then :red
+                     when "Following" then :blue
+                     when "Well Cooked" then :brown
+                     else :green
                    end
     %>
-    <% if current_page?(explore_gallery_path) %>
-      <%
-        current_sort = params[:sort].presence || "newest"
-        cooked_toggle_url = cooked_active ? "#{base_path}?sort=#{current_sort}" : "#{base_path}?sort=#{current_sort}&filter=cooked"
-      %>
-      <%= link_to cooked_toggle_url, class: "explore__cooked-filter #{'active' if cooked_active}" do %>
-        <span class="explore__cooked-filter-checkbox"><%= cooked_active ? "✓" : "" %></span>
-        🔥 Cooked
-      <% end %>
-    <% end %>
     <%= render DropdownComponent.new(
       label: "Sort",
       options: sort_options,
       selected_option: selected_label,
-      longest_option_string: "Following",
+      longest_option_string: "Well Cooked",
       color: sort_color
     ) %>
   </div>

--- a/app/views/explore/_explore_nav.html.erb
+++ b/app/views/explore/_explore_nav.html.erb
@@ -39,13 +39,16 @@
   <div class="explore__nav--sort">
     <%
       base_path = request.path
+      cooked_active = params[:filter] == "cooked"
+      cooked_suffix = cooked_active ? "&filter=cooked" : ""
+
       sort_options = [
-        { label: "Newest", value: "#{base_path}?sort=newest" },
-        { label: "Top", value: "#{base_path}?sort=top" }
+        { label: "Newest", value: "#{base_path}?sort=newest#{cooked_suffix}" },
+        { label: "Top", value: "#{base_path}?sort=top#{cooked_suffix}" }
       ]
 
       if current_user
-        sort_options << { label: "Following", value: "#{base_path}?sort=following" }
+        sort_options << { label: "Following", value: "#{base_path}?sort=following#{cooked_suffix}" }
       end
 
       selected_label = case params[:sort]
@@ -60,6 +63,16 @@
                    else :green
                    end
     %>
+    <% if current_page?(explore_gallery_path) %>
+      <%
+        current_sort = params[:sort].presence || "newest"
+        cooked_toggle_url = cooked_active ? "#{base_path}?sort=#{current_sort}" : "#{base_path}?sort=#{current_sort}&filter=cooked"
+      %>
+      <%= link_to cooked_toggle_url, class: "explore__cooked-filter #{'active' if cooked_active}" do %>
+        <span class="explore__cooked-filter-checkbox"><%= cooked_active ? "✓" : "" %></span>
+        🔥 Cooked
+      <% end %>
+    <% end %>
     <%= render DropdownComponent.new(
       label: "Sort",
       options: sort_options,


### PR DESCRIPTION
This pull request adds a filter for Well Cooked projects on the /explore/gallery page.

Attaching screenshots:
<img width="1469" height="810" alt="Screenshot 2026-04-03 at 12 20 50 PM" src="https://github.com/user-attachments/assets/acc3eef6-94ff-4ce4-9e8f-8692bfd35100" />
<img width="1467" height="809" alt="image" src="https://github.com/user-attachments/assets/5b54daab-fcca-4cec-b499-04b289832050" />
<img width="1470" height="805" alt="image" src="https://github.com/user-attachments/assets/785624da-6d4a-4ff5-b8d4-b62f8ae8ea7d" />
