### PR TITLE
feat: Achievement tag for shop items card

### DIFF
--- a/app/assets/stylesheets/components/_shop-item-card.scss
+++ b/app/assets/stylesheets/components/_shop-item-card.scss
@@ -31,6 +31,16 @@
     border: 2px solid #dc2626;
   }
 
+  &--achievement-locked {
+    box-shadow:
+      0 10px 28px rgba(120, 53, 15, 0.16),
+      0 0 0 1px rgba(245, 158, 11, 0.18) inset;
+
+    &::before {
+      filter: saturate(1.05) brightness(1.03);
+    }
+  }
+
   &--with-bow {
     overflow: visible;
   }
@@ -368,10 +378,61 @@
     color: #a87254;
     font-family: var(--font-family-text);
     display: -webkit-box;
+    line-clamp: 2;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
     min-height: 2.4em;
+  }
+
+  &__achievement-lock-slot {
+    width: 100%;
+    min-height: 1.9rem;
+    margin-top: 0rem;
+  }
+
+  &__achievement-lock-badge {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    width: 100%;
+    background: linear-gradient(135deg, rgba(255, 247, 237, 0.98), rgba(254, 243, 199, 0.92));
+    color: #7c2d12;
+    border: 1px solid rgba(180, 83, 9, 0.18);
+    border-radius: 999px;
+    font-family: var(--font-family-text);
+    font-size: 0.82rem;
+    line-height: 1.2;
+    padding: 0.28rem 0.55rem;
+    letter-spacing: 0.01em;
+    overflow: hidden;
+    box-shadow: 0 4px 10px rgba(120, 53, 15, 0.08);
+  }
+
+  &__achievement-lock-badge-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 999px;
+    background: rgba(245, 158, 11, 0.14);
+    color: #b45309;
+
+    svg {
+      width: 0.7rem;
+      height: 0.7rem;
+    }
+  }
+
+  &__achievement-lock-badge-text {
+    color: #78350f;
+    font-weight: 600;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   &__enabled-until {

--- a/app/assets/stylesheets/components/_shop-item-card.scss
+++ b/app/assets/stylesheets/components/_shop-item-card.scss
@@ -282,6 +282,7 @@
       text-decoration: none;
     }
   }
+
   &::before {
     content: "";
     position: absolute;
@@ -388,7 +389,7 @@
   &__achievement-lock-slot {
     width: 100%;
     min-height: 1.9rem;
-    margin-top: 0rem;
+    margin-top: 0;
   }
 
   &__achievement-lock-badge {
@@ -396,7 +397,11 @@
     align-items: center;
     gap: 0.45rem;
     width: 100%;
-    background: linear-gradient(135deg, rgba(255, 247, 237, 0.98), rgba(254, 243, 199, 0.92));
+    background: linear-gradient(
+      135deg,
+      rgba(255, 247, 237, 0.98),
+      rgba(254, 243, 199, 0.92)
+    );
     color: #7c2d12;
     border: 1px solid rgba(180, 83, 9, 0.18);
     border-radius: 999px;

--- a/app/components/shop_item_card_component.html.erb
+++ b/app/components/shop_item_card_component.html.erb
@@ -1,4 +1,4 @@
-<div class="shop-item-card<%= ' shop-item-card--out-of-stock' if out_of_stock? %><%= ' shop-item-card--on-sale' if on_sale %><%= ' shop-item-card--with-bow' if show_bow %>"
+<div class="shop-item-card<%= ' shop-item-card--out-of-stock' if out_of_stock? %><%= ' shop-item-card--on-sale' if on_sale %><%= ' shop-item-card--with-bow' if show_bow %><%= ' shop-item-card--achievement-locked' if show_achievement_lock_badge? %>"
      data-categories="<%= categories.join(',') %>"
      data-regions="<%= enabled_regions.join(',') %>"
      data-shop-id="<%= item_id %>"
@@ -53,6 +53,16 @@
       <div class="shop-item-card__content">
         <h4 class="shop-item-card__title"><%= name %></h4>
         <div class="shop-item-card__description"><%= md(description) %></div>
+        <div class="shop-item-card__achievement-lock-slot" aria-hidden="<%= !show_achievement_lock_badge? %>">
+          <% if show_achievement_lock_badge? %>
+            <div class="shop-item-card__achievement-lock-badge" title="<%= achievement_lock_badge_title %>">
+              <span class="shop-item-card__achievement-lock-badge-icon" aria-hidden="true">
+                <%= helpers.inline_svg_tag "icons/trophy.svg", focusable: "false" %>
+              </span>
+              <span class="shop-item-card__achievement-lock-badge-text"><%= achievement_lock_badge_text %></span>
+            </div>
+          <% end %>
+        </div>
         <% if enabled_until.present? %>
           <div class="shop-item-card__enabled-until">Enabled until <%= enabled_until.strftime("%b %d, %Y") %></div>
         <% end %>
@@ -82,6 +92,16 @@
       <div class="shop-item-card__content">
         <h4 class="shop-item-card__title"><%= name %></h4>
         <div class="shop-item-card__description"><%= md(description) %></div>
+        <div class="shop-item-card__achievement-lock-slot" aria-hidden="<%= !show_achievement_lock_badge? %>">
+          <% if show_achievement_lock_badge? %>
+            <div class="shop-item-card__achievement-lock-badge" title="<%= achievement_lock_badge_title %>">
+              <span class="shop-item-card__achievement-lock-badge-icon" aria-hidden="true">
+                <%= helpers.inline_svg_tag "icons/trophy.svg", focusable: "false" %>
+              </span>
+              <span class="shop-item-card__achievement-lock-badge-text"><%= achievement_lock_badge_text %></span>
+            </div>
+          <% end %>
+        </div>
         <% if enabled_until.present? %>
           <div class="shop-item-card__enabled-until">Enabled until <%= enabled_until.strftime("%b %d, %Y") %></div>
         <% end %>

--- a/app/components/shop_item_card_component.rb
+++ b/app/components/shop_item_card_component.rb
@@ -1,9 +1,9 @@
 class ShopItemCardComponent < ViewComponent::Base
   include MarkdownHelper
 
-  attr_reader :item_id, :name, :description, :hours, :price, :image_url, :item_type, :balance, :enabled_regions, :regional_price, :logged_in, :remaining_stock, :limited, :on_sale, :sale_percentage, :original_price, :created_at, :show_bow, :show_time_ago, :purchase_count, :is_new, :enabled_until
+  attr_reader :item_id, :name, :description, :hours, :price, :image_url, :item_type, :balance, :enabled_regions, :regional_price, :logged_in, :remaining_stock, :limited, :on_sale, :sale_percentage, :original_price, :created_at, :show_bow, :show_time_ago, :purchase_count, :is_new, :enabled_until, :achievement_requirement_names, :locked_by_achievement
 
-  def initialize(item_id:, name:, description:, hours:, price:, image_url:, item_type: nil, balance: nil, enabled_regions: [], regional_price: nil, logged_in: true, remaining_stock: nil, limited: false, on_sale: false, sale_percentage: nil, original_price: nil, created_at: nil, show_bow: false, show_time_ago: false, purchase_count: nil, is_new: false, enabled_until: nil)
+  def initialize(item_id:, name:, description:, hours:, price:, image_url:, item_type: nil, balance: nil, enabled_regions: [], regional_price: nil, logged_in: true, remaining_stock: nil, limited: false, on_sale: false, sale_percentage: nil, original_price: nil, created_at: nil, show_bow: false, show_time_ago: false, purchase_count: nil, is_new: false, enabled_until: nil, achievement_requirement_names: [], locked_by_achievement: false)
     @item_id = item_id
     @name = name
     @description = description
@@ -26,6 +26,8 @@ class ShopItemCardComponent < ViewComponent::Base
     @purchase_count = purchase_count
     @is_new = is_new
     @enabled_until = enabled_until
+    @achievement_requirement_names = achievement_requirement_names
+    @locked_by_achievement = locked_by_achievement
   end
 
   def time_ago_text
@@ -69,5 +71,21 @@ class ShopItemCardComponent < ViewComponent::Base
 
   def show_stock_indicator?
     limited && remaining_stock.present? && remaining_stock <= 10
+  end
+
+  def show_achievement_lock_badge?
+    locked_by_achievement && achievement_requirement_names.present?
+  end
+
+  def achievement_lock_badge_title
+    return nil unless achievement_requirement_names.present?
+
+    "Requires: #{achievement_requirement_names.to_sentence(two_words_connector: ' or ', last_word_connector: ', or ')}"
+  end
+
+  def achievement_lock_badge_text
+    return nil unless achievement_requirement_names.present?
+
+    "Requires #{achievement_requirement_names.to_sentence(two_words_connector: ' or ', last_word_connector: ', or ')}"
   end
 end

--- a/app/views/shop/index.html.erb
+++ b/app/views/shop/index.html.erb
@@ -139,6 +139,7 @@
         <% @shop_items.each do |item| %>
           <% if item.image.present? && item.enabled_in_region?(@user_region) %>
             <% sale_price = item.price_for_region(@user_region) %>
+            <% achievement_requirement_names = item.requires_achievement? ? item.requires_achievement.map { |slug| Achievement.find(slug).name } : [] %>
             <%= render ShopItemCardComponent.new(
               item_id: item.id,
               name: item.name,
@@ -158,7 +159,9 @@
               original_price: item.base_price_for_region(@user_region),
               purchase_count: item.display_purchase_count,
               is_new: item.new_item?,
-              enabled_until: item.enabled_until
+              enabled_until: item.enabled_until,
+              achievement_requirement_names: achievement_requirement_names,
+              locked_by_achievement: item.requires_achievement? && !item.meet_achievement_require?(current_user)
             ) %>
           <% end %>
         <% end %>


### PR DESCRIPTION
Display a tag on the item card when it is locked behind an achievement the user has not yet earned

<img width="941" height="605" alt="image" src="https://github.com/user-attachments/assets/f326892f-c737-4d5e-8445-32d9044ad85f" />
