### PR TITLE
fix(shop-suggestions): fix broken sync job

### DIFF
--- a/app/jobs/airtable/shop_suggestion_sync_job.rb
+++ b/app/jobs/airtable/shop_suggestion_sync_job.rb
@@ -9,17 +9,18 @@ class Airtable::ShopSuggestionSyncJob < ApplicationJob
     suggestion = ShopSuggestion.find_by(id: shop_suggestion_id)
     return if suggestion.nil?
 
-    table.upsert(field_mapping(suggestion), "ID")
+    table.create(field_mapping(suggestion))
   end
 
   private
 
   def field_mapping(suggestion)
     {
-      "ID" => SecureRandom.uuid,
       "Item" => suggestion.item.to_s,
       "Link" => suggestion.link.presence,
-      "Notes" => suggestion.explanation.to_s
+      "Notes" => suggestion.explanation.to_s,
+      "User ID" => suggestion.user&.id&.to_s,
+      "Slack ID" => suggestion.user&.slack_id
     }
   end
 


### PR DESCRIPTION
The ID field was changed to auto-number and it broke the upsert. Also added `User ID` and `Slack ID` to the job so those are recorded in the Airtable too.

Fixes #2045 and allows @transcental to fix #1947 