### PR TITLE
feat(super-mega): added category-wise pie chart for HCB transactions

### DIFF
--- a/app/assets/stylesheets/pages/admin/_super_mega_dashboard.scss
+++ b/app/assets/stylesheets/pages/admin/_super_mega_dashboard.scss
@@ -33,6 +33,28 @@
     &--green {
       color: #388e3c;
     }
+
+    &--brown {
+      color: #92400e;
+    }
+  }
+
+  &__hcb-layout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    align-items: stretch;
+  }
+
+  &__stats--hcb {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    height: 100%;
+  }
+
+  &__card-title--centered h3 {
+    text-align: center;
   }
 
   &__dashboards {

--- a/app/controllers/admin/super_mega_dashboard_controller.rb
+++ b/app/controllers/admin/super_mega_dashboard_controller.rb
@@ -33,6 +33,7 @@ module Admin
       super_mega_nps_stats
       super_mega_nps_vibes
       super_mega_hcb_stats
+      super_mega_hcb_stats_v2
     ].freeze
 
     SECTIONS = {

--- a/app/controllers/concerns/admin/super_mega_dashboard/misc_stats.rb
+++ b/app/controllers/concerns/admin/super_mega_dashboard/misc_stats.rb
@@ -253,7 +253,7 @@ module Admin
       end
 
       def load_hcb_expenses
-        data = Rails.cache.fetch("super_mega_hcb_stats", expires_in: 5.minutes) do
+        data = Rails.cache.fetch("super_mega_hcb_stats", expires_in: 1.hour) do
           response = Faraday.get("https://hcb.hackclub.com/api/v3/organizations/flavortown")
 
           if response.success?
@@ -275,6 +275,47 @@ module Admin
         @balance_cents = data[:balance_cents] || 0
         @total_expenses_cents = data[:total_expenses_cents] || 0
         @total_raised_cents = data[:total_raised_cents] || 0
+        @hcb_spending_by_tag = fetch_hcb_spending_by_tag
+      end
+
+      def fetch_hcb_spending_by_tag
+        Rails.cache.fetch("super_mega_hcb_stats_v2", expires_in: 1.hour) do
+          spending_by_tag = {}
+          current_page = 1
+
+          loop do
+            response = Faraday.get("https://hcb.hackclub.com/api/v3/organizations/flavortown/transactions", { page: current_page, per_page: 50 })
+            break unless response.success?
+
+            data = JSON.parse(response.body)
+            break if data.empty?
+
+            data.each do |txn|
+              amount = txn["amount_cents"].to_i
+              next unless amount < 0
+
+              tags = txn["tags"] || []
+              tag_names = tags.map { |tag| tag["label"] }
+
+              if tag_names.any?
+                tag_names.each do |tag_name|
+                  spending_by_tag[tag_name] ||= 0
+                  spending_by_tag[tag_name] += amount.abs
+                end
+              else
+                spending_by_tag["Untagged"] ||= 0
+                spending_by_tag["Untagged"] += amount.abs
+              end
+            end
+
+            current_page += 1
+          end
+
+          spending_by_tag.transform_values { |amount| amount / 100.0 }
+        rescue StandardError => e
+          Rails.logger.error("[SuperMegaDashboard] Error fetching HCB spending by tag: #{e.class} - #{e.message}")
+          {}
+        end
       end
 
       def load_flavortime_summary

--- a/app/javascript/controllers/hcb_chart_controller.js
+++ b/app/javascript/controllers/hcb_chart_controller.js
@@ -1,0 +1,93 @@
+import { Controller } from "@hotwired/stimulus";
+import Chart from "chart.js/auto";
+
+export default class extends Controller {
+  static targets = ["canvas"];
+  static values = { spendingData: Object };
+
+  connect() {
+    if (this.hasCanvasTarget && this.hasSpendingDataValue) {
+      this.render();
+    }
+  }
+
+  render() {
+    const data = this.spendingDataValue;
+    const labels = Object.keys(data);
+    const values = Object.values(data);
+
+    if (labels.length === 0 || values.length === 0) {
+      return;
+    }
+
+    const colors = [
+      "#ef4444",
+      "#f97316",
+      "#eab308",
+      "#22c55e",
+      "#06b6d4",
+      "#0ea5e9",
+      "#3b82f6",
+      "#8b5cf6",
+      "#ec4899",
+      "#f43f5e",
+      "#6366f1",
+      "#a855f7",
+      "#d946ef",
+      "#db2777",
+      "#be185d",
+      "#7c2d12",
+      "#292524",
+      "#64748b",
+    ];
+
+    new Chart(this.canvasTarget, {
+      type: "doughnut",
+      data: {
+        labels: labels,
+        datasets: [
+          {
+            data: values,
+            backgroundColor: colors.slice(0, labels.length),
+            borderColor: "#ffffff",
+            borderWidth: 2,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            position: "bottom",
+            labels: {
+              padding: 15,
+              font: { size: 12 },
+            },
+          },
+          tooltip: {
+            callbacks: {
+              label: (context) => {
+                const label = context.label || "";
+                const value = context.parsed || 0;
+                const total = context.dataset.data.reduce((a, b) => a + b, 0);
+                const percentage = ((value / total) * 100).toFixed(1);
+                return (
+                  label +
+                  ": $" +
+                  value.toLocaleString("en-US", {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  }) +
+                  " (" +
+                  percentage +
+                  "%)"
+                );
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -168,3 +168,6 @@ application.register("lazy-load", LazyLoadController);
 
 import SuperMegaFunnelController from "./super_mega_funnel_controller";
 application.register("super-mega-funnel", SuperMegaFunnelController);
+
+import HcbChartController from "./hcb_chart_controller";
+application.register("hcb-chart", HcbChartController);

--- a/app/views/admin/super_mega_dashboard/sections/_hcb.html.erb
+++ b/app/views/admin/super_mega_dashboard/sections/_hcb.html.erb
@@ -6,19 +6,87 @@
   <% if @hcb_error.present? %>
     <p class="fraud-stats-error"><%= @hcb_error %></p>
   <% else %>
-    <div class="super-mega-dashboard__stats">
-      <div class="super-mega-dashboard__card">
-        <h3>Balance</h3>
-        <p class="balance <%= balance_color_class(@balance_cents) %>">
-          $<%= number_with_delimiter(@balance_cents / 100) %>
-        </p>
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; align-items: stretch;">
+      <div class="super-mega-dashboard__stats" style="display: flex; flex-direction: column; gap: 1rem; height: 100%;">
+        <div class="super-mega-dashboard__card">
+          <h3>Balance</h3>
+          <p class="balance <%= balance_color_class(@balance_cents) %>">
+            $<%= number_with_delimiter(@balance_cents / 100) %>
+          </p>
+        </div>
+        <div class="super-mega-dashboard__card">
+          <h3>Total Spent</h3>
+          <p class="balance" style="color: #ef4444;">
+            $<%= number_with_delimiter(@total_expenses_cents / 100) %>
+          </p>
+        </div>
+        <div class="super-mega-dashboard__card">
+          <h3>Total Revenue</h3>
+          <p class="balance" style="color: #92400e;">
+            $<%= number_with_delimiter(@total_raised_cents / 100) %>
+          </p>
+        </div>
       </div>
-      <div class="super-mega-dashboard__card">
-        <h3>Total Spent</h3>
-        <p class="balance">
-          $<%= number_with_delimiter(@total_expenses_cents / 100) %>
-        </p>
-      </div>
+      <% if @hcb_spending_by_tag.present? %>
+        <div class="super-mega-dashboard__card" style="height: 100%; display: flex; flex-direction: column;">
+          <h3 style="text-align: center;">Spending by Tags</h3>
+          <div style="height: 300px; position: relative; flex: 1;">
+            <canvas id="hcbSpendingChart" height="300"></canvas>
+          </div>
+          <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+          <script>
+            document.addEventListener('DOMContentLoaded', function() {
+              const ctx = document.getElementById('hcbSpendingChart');
+              if (!ctx) return;
+              const data = <%= raw @hcb_spending_by_tag.to_json %>;
+              const labels = Object.keys(data);
+              const values = Object.values(data);
+              const colors = [
+                '#ef4444', '#f97316', '#eab308', '#22c55e', '#06b6d4', '#0ea5e9',
+                '#3b82f6', '#8b5cf6', '#ec4899', '#f43f5e', '#6366f1', '#a855f7',
+                '#d946ef', '#db2777', '#be185d', '#7c2d12', '#292524', '#64748b'
+              ];
+              
+              new Chart(ctx, {
+                type: 'doughnut',
+                data: {
+                  labels: labels,
+                  datasets: [{
+                    data: values,
+                    backgroundColor: colors.slice(0, labels.length),
+                    borderColor: '#ffffff',
+                    borderWidth: 2
+                  }]
+                },
+                options: {
+                  responsive: true,
+                  maintainAspectRatio: false,
+                  plugins: {
+                    legend: {
+                      position: 'bottom',
+                      labels: {
+                        padding: 15,
+                        font: { size: 12 }
+                      }
+                    },
+                    tooltip: {
+                      callbacks: {
+                        label: function(context) {
+                          const label = context.label || '';
+                          const value = context.parsed || 0;
+                          const total = context.dataset.data.reduce((a, b) => a + b, 0);
+                          const percentage = ((value / total) * 100).toFixed(1);
+                          return label + ': $' + value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' (' + percentage + '%)';
+                        }
+                      }
+                    }
+                  }
+                }
+              });
+            });
+          </script>
+        </div>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/admin/super_mega_dashboard/sections/_hcb.html.erb
+++ b/app/views/admin/super_mega_dashboard/sections/_hcb.html.erb
@@ -31,13 +31,11 @@
         <div
           class="super-mega-dashboard__card"
           data-controller="hcb-chart"
-          data-hcb-chart-spending-data-value="<%= @hcb_spending_by_tag.to_json %>"
-        >
+          data-hcb-chart-spending-data-value="<%= @hcb_spending_by_tag.to_json %>">
           <h3 style="text-align: center;">Spending by Tags</h3>
           <div>
             <canvas
-              data-hcb-chart-target="canvas"
-            ></canvas>
+              data-hcb-chart-target="canvas"></canvas>
           </div>
         </div>
       <% end %>

--- a/app/views/admin/super_mega_dashboard/sections/_hcb.html.erb
+++ b/app/views/admin/super_mega_dashboard/sections/_hcb.html.erb
@@ -6,8 +6,8 @@
   <% if @hcb_error.present? %>
     <p class="fraud-stats-error"><%= @hcb_error %></p>
   <% else %>
-    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; align-items: stretch;">
-      <div class="super-mega-dashboard__stats" style="display: flex; flex-direction: column; gap: 1rem; height: 100%;">
+    <div class="super-mega-dashboard__hcb-layout">
+      <div class="super-mega-dashboard__stats super-mega-dashboard__stats--hcb">
         <div class="super-mega-dashboard__card">
           <h3>Balance</h3>
           <p class="balance <%= balance_color_class(@balance_cents) %>">
@@ -16,23 +16,23 @@
         </div>
         <div class="super-mega-dashboard__card">
           <h3>Total Spent</h3>
-          <p class="balance" style="color: #ef4444;">
+          <p class="balance balance--red">
             $<%= number_with_delimiter(@total_expenses_cents / 100) %>
           </p>
         </div>
         <div class="super-mega-dashboard__card">
           <h3>Total Revenue</h3>
-          <p class="balance" style="color: #92400e;">
+          <p class="balance balance--brown">
             $<%= number_with_delimiter(@total_raised_cents / 100) %>
           </p>
         </div>
       </div>
       <% if @hcb_spending_by_tag.present? %>
         <div
-          class="super-mega-dashboard__card"
+          class="super-mega-dashboard__card super-mega-dashboard__card-title--centered"
           data-controller="hcb-chart"
           data-hcb-chart-spending-data-value="<%= @hcb_spending_by_tag.to_json %>">
-          <h3 style="text-align: center;">Spending by Tags</h3>
+          <h3>Spending by Tags</h3>
           <div>
             <canvas
               data-hcb-chart-target="canvas"></canvas>

--- a/app/views/admin/super_mega_dashboard/sections/_hcb.html.erb
+++ b/app/views/admin/super_mega_dashboard/sections/_hcb.html.erb
@@ -28,63 +28,17 @@
         </div>
       </div>
       <% if @hcb_spending_by_tag.present? %>
-        <div class="super-mega-dashboard__card" style="height: 100%; display: flex; flex-direction: column;">
+        <div
+          class="super-mega-dashboard__card"
+          data-controller="hcb-chart"
+          data-hcb-chart-spending-data-value="<%= @hcb_spending_by_tag.to_json %>"
+        >
           <h3 style="text-align: center;">Spending by Tags</h3>
-          <div style="height: 300px; position: relative; flex: 1;">
-            <canvas id="hcbSpendingChart" height="300"></canvas>
+          <div>
+            <canvas
+              data-hcb-chart-target="canvas"
+            ></canvas>
           </div>
-          <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-          <script>
-            document.addEventListener('DOMContentLoaded', function() {
-              const ctx = document.getElementById('hcbSpendingChart');
-              if (!ctx) return;
-              const data = <%= raw @hcb_spending_by_tag.to_json %>;
-              const labels = Object.keys(data);
-              const values = Object.values(data);
-              const colors = [
-                '#ef4444', '#f97316', '#eab308', '#22c55e', '#06b6d4', '#0ea5e9',
-                '#3b82f6', '#8b5cf6', '#ec4899', '#f43f5e', '#6366f1', '#a855f7',
-                '#d946ef', '#db2777', '#be185d', '#7c2d12', '#292524', '#64748b'
-              ];
-              
-              new Chart(ctx, {
-                type: 'doughnut',
-                data: {
-                  labels: labels,
-                  datasets: [{
-                    data: values,
-                    backgroundColor: colors.slice(0, labels.length),
-                    borderColor: '#ffffff',
-                    borderWidth: 2
-                  }]
-                },
-                options: {
-                  responsive: true,
-                  maintainAspectRatio: false,
-                  plugins: {
-                    legend: {
-                      position: 'bottom',
-                      labels: {
-                        padding: 15,
-                        font: { size: 12 }
-                      }
-                    },
-                    tooltip: {
-                      callbacks: {
-                        label: function(context) {
-                          const label = context.label || '';
-                          const value = context.parsed || 0;
-                          const total = context.dataset.data.reduce((a, b) => a + b, 0);
-                          const percentage = ((value / total) * 100).toFixed(1);
-                          return label + ': $' + value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' (' + percentage + '%)';
-                        }
-                      }
-                    }
-                  }
-                }
-              });
-            });
-          </script>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
**Changes:**
- Added a pie chart for transactions based on tags.
- Added a revenue statistic
**Note:** Added 1-hour cache as opposed to 5-minute, as fetching all transactions takes a lot of time from the HCB API

<img width="1112" height="501" alt="image" src="https://github.com/user-attachments/assets/bdddaa89-bda0-4648-898c-6b3c0a63de68" />
<img width="1079" height="517" alt="image" src="https://github.com/user-attachments/assets/1a61c053-ef21-4fa3-be96-929bee7d18ee" />
<img width="1113" height="501" alt="image" src="https://github.com/user-attachments/assets/ff7302e0-59dd-4c59-90d0-f24605d3c01e" />
