### PR TITLE
style(super-mega): removed empty space & unnecessary scroll bar

### DIFF
--- a/app/assets/stylesheets/pages/admin/_super_mega_dashboard.scss
+++ b/app/assets/stylesheets/pages/admin/_super_mega_dashboard.scss
@@ -2444,7 +2444,7 @@
     display: flex;
     align-items: center;
     gap: 0.25rem;
-    overflow-y: scroll;
+    overflow: auto;
   }
 
   &__suggestion {

--- a/app/views/admin/super_mega_dashboard/sections/_sidequests.html.erb
+++ b/app/views/admin/super_mega_dashboard/sections/_sidequests.html.erb
@@ -4,7 +4,7 @@
     <%= link_to "View Sidequest Entries →", admin_sidequest_entries_path, class: "super-mega-link" %>
   </div>
 
-  <div class="super-mega-dashboard__cards">
+  <div class="super-mega-dashboard__cards super-mega-dashboard__cards--sidequests">
     <div class="super-mega-dashboard__card">
       <h3>Queue + Velocity</h3>
       <div class="super-mega-dashboard__stats super-mega-dashboard__stats--sidequests">


### PR DESCRIPTION
## Empty Space
**Before:**
<img width="1590" height="793" alt="image" src="https://github.com/user-attachments/assets/d92628ac-0b5d-4100-9e60-a5616a9b06ba" />


**After**
<img width="1581" height="787" alt="image" src="https://github.com/user-attachments/assets/965564b9-5287-4e04-91ab-f36fa66eb518" />


## Unnecessary Scrollbar
**Before:**
<img width="1084" height="200" alt="image" src="https://github.com/user-attachments/assets/ecb51f00-64bc-48bf-8d35-dfdebfe90b2e" />

**After:**
<img width="1075" height="195" alt="image" src="https://github.com/user-attachments/assets/32762739-7536-44d9-8701-28ac85a7d44b" />
