### PR TITLE
fix: Make the Access shop filter actually work

### DIFF
--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -30,7 +30,8 @@ export default class extends Controller {
       label === "Category" ||
       label === "Price Range" ||
       label === "Sort by" ||
-      label === "Region"
+      label === "Region" ||
+      label === "Access"
     ) {
       document.dispatchEvent(
         new CustomEvent("shop:filter", {


### PR DESCRIPTION
(Why is the list of dropdowns that trigger filtering in the _dropdown_ controller and not the _shop_ controller? oh well too late)

<img width="1502" height="731" alt="image" src="https://github.com/user-attachments/assets/c8787b01-2f73-4fe8-8fe2-e22550694407" />

closes #2117 