### PR TITLE
fix!: add embeddings db to docker compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       pull-requests: write
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -91,9 +91,19 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+      postgres_embed:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: flavortown_test_embed
+        ports:
+          - 5433:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
     env:
       RAILS_ENV: test
       DATABASE_URL: postgresql://postgres:password@localhost:5432/flavortown_test
+      EMBEDDINGS_DATABASE_URL: postgresql://postgres:password@localhost:5433/flavortown_test_embed
     steps:
       - uses: actions/checkout@v6
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - FERRET=${FERRET:-}
     depends_on:
       - db
+      - dbe
 
   db:
     image: postgres:16
@@ -27,7 +28,19 @@ services:
     ports:
       - "5432:5432"
 
+  dbe:
+    image: pgvector/pgvector:pg16
+    volumes:
+      - flavortown_postgres_data_e:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=pass
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=flavortown_development_embed
+    ports:
+      - "5433:5432"
+
 volumes:
   flavortown_postgres_data:
+  flavortown_postgres_data_e:
   bundle_cache:
   node_modules_cache:

--- a/example.env
+++ b/example.env
@@ -1,6 +1,7 @@
 #### You WILL need this for local development.
 # If you used `docker compose up -d db`, you don't need to change this.
 DATABASE_URL=postgresql://postgres:pass@db:5432/flavortown_development
+EMBEDDINGS_DATABASE_URL=postgresql://postgres:pass@dbe:5432/flavortown_development_embed
 
 # Generate one via `openssl rand -hex 64`.
 SECRET_KEY_BASE=91a016c2f22f34fcc57179e7f50fb74c4d7642f61be81b5044b544a008b67e1ce421cb0b7a357d62e262ac969654b9e71d98b32e5ca162072032a86720892ecc


### PR DESCRIPTION
- add additional pgvector database to docker-compose.yml
- add relevant environment variable to example.env

these changes make it possible to run a development environment easily again

you should:
1. stop and delete your existing containers: `docker compose down --remove-orphans` 
2. start the new databases & run the migrations: `docker compose run web bin/rails db:migrate` 
3. get a shell: `docker compose run --remove-orphans --service-ports web /bin/bash`
4. resume cooking: `bin/dev`