### PR TITLE
feat(sidequest): fixed UI for physics lab page

### DIFF
--- a/app/assets/stylesheets/pages/sidequests/_show.scss
+++ b/app/assets/stylesheets/pages/sidequests/_show.scss
@@ -40,6 +40,12 @@
       font-size: 0.95rem;
       font-style: italic;
     }
+    #physics-lab-canvas {
+      width: 95%;
+      max-width: 95%;
+      height: auto;
+      display: block;
+    }
 
     .sidequest-show__prizes-card {
       margin-top: 1rem;


### PR DESCRIPTION
Before: <img width="2145" height="1425" alt="Screenshot 2026-04-10 171854" src="https://github.com/user-attachments/assets/f80980e8-e722-45fb-be44-e084f56c3c0b" />
After:
<img width="1880" height="1309" alt="Screenshot 2026-04-10 172008" src="https://github.com/user-attachments/assets/f852ec80-9062-4912-ae5d-c0bf6711f4cf" />
