### PR TITLE
fix(super-mega): reverse "Make Their Day" projects order

### DIFF
--- a/app/controllers/concerns/admin/super_mega_dashboard/shipwrights_stats.rb
+++ b/app/controllers/concerns/admin/super_mega_dashboard/shipwrights_stats.rb
@@ -157,6 +157,8 @@ module Admin
         raw = @ship_certs&.dig(:make_their_day_raw) || []
         return @sw_make_their_day = [] unless raw.any?
 
+        raw = raw.reverse
+
         project_ids = raw.map { |p| p["ftProjectId"] }.compact
         user_ids    = raw.map { |p| p["requesterFtuid"] }.compact
 

--- a/app/controllers/concerns/admin/super_mega_dashboard/shipwrights_stats.rb
+++ b/app/controllers/concerns/admin/super_mega_dashboard/shipwrights_stats.rb
@@ -158,7 +158,6 @@ module Admin
         return @sw_make_their_day = [] unless raw.any?
 
         raw = raw.reverse
-
         project_ids = raw.map { |p| p["ftProjectId"] }.compact
         user_ids    = raw.map { |p| p["requesterFtuid"] }.compact
 


### PR DESCRIPTION
New Projects in the "Make Their Day" carousel on Shipwrights Dash were being added to the end of the carousel.