### PR TITLE
fix(ship): re ship  gets sent thru the dash!

### DIFF
--- a/app/controllers/projects/ships_controller.rb
+++ b/app/controllers/projects/ships_controller.rb
@@ -45,7 +45,7 @@ class Projects::ShipsController < ApplicationController
       redirect_to @project, notice: "Congratulations! Your project has been submitted for review!"
     else
       ShipCertWebhookJob.perform_later(ship_event_id: @post.postable.id, type: "reship")
-      redirect_to @project, notice: "Ship submitted! Your project is now out for voting."
+      redirect_to @project, notice: "Ship submitted! Your project has been submitted for certification review and will be available for voting after approval."
     end
   rescue ActiveRecord::RecordInvalid => e
     redirect_back fallback_location: new_project_ships_path(@project), alert: e.record.errors.full_messages.to_sentence

--- a/app/controllers/projects/ships_controller.rb
+++ b/app/controllers/projects/ships_controller.rb
@@ -44,7 +44,7 @@ class Projects::ShipsController < ApplicationController
       ShipCertWebhookJob.perform_later(ship_event_id: @post.postable.id, type: "initial")
       redirect_to @project, notice: "Congratulations! Your project has been submitted for review!"
     else
-      @post.postable.update!(certification_status: "approved")
+      ShipCertWebhookJob.perform_later(ship_event_id: @post.postable.id, type: "reship")
       redirect_to @project, notice: "Ship submitted! Your project is now out for voting."
     end
   rescue ActiveRecord::RecordInvalid => e

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -159,9 +159,3 @@ production:
     schedule: every 12 hours
     concurrency: 1
     description: "Recompute vote quality scores and update blessed/cursed/neutral verdicts for all voters"
-
-  project_reship_events_sync:
-    class: Project::ReshipEventsSyncJob
-    schedule: every day at 7am America/New_York
-    concurrency: 1
-    description: "Sync projects with multiple ship events and log each event"


### PR DESCRIPTION
We recently had a change where re ships should no longer be insta approved and instead go thru the ship cert dash. A cron job implementation was pushed to fix this but only runs at 7am which causes a couple issues. This pr also retires the cron job as it would handle re ships this way instead.