### PR TITLE
fix(dev): allow local r2 buckets when defined

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,8 +37,8 @@ Rails.application.configure do
   # Change to :null_store to avoid any caching.
   config.cache_store = :memory_store
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # Use Cloudflare R2 when env vars are set, otherwise fall back to local disk.
+  config.active_storage.service = ENV["CLOUDFLARE_R2_ACCESS_KEY_ID"].present? ? :cloudflare : :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -9,11 +9,11 @@ local:
 
 cloudflare:
   service: S3
-  endpoint: https://<%= Rails.application.credentials.dig(:cloudflare, :account_id) %>.r2.cloudflarestorage.com
-  access_key_id: <%= Rails.application.credentials.dig(:cloudflare, :access_key_id) %>
-  secret_access_key: <%= Rails.application.credentials.dig(:cloudflare, :secret_access_key) %>
+  endpoint: https://<%= ENV.fetch("CLOUDFLARE_ACCOUNT_ID", Rails.application.credentials.dig(:cloudflare, :account_id)) %>.r2.cloudflarestorage.com
+  access_key_id: <%= ENV.fetch("CLOUDFLARE_R2_ACCESS_KEY_ID", Rails.application.credentials.dig(:cloudflare, :access_key_id)) %>
+  secret_access_key: <%= ENV.fetch("CLOUDFLARE_R2_SECRET_ACCESS_KEY", Rails.application.credentials.dig(:cloudflare, :secret_access_key)) %>
   region: auto
-  bucket: <%= Rails.application.credentials.dig(:cloudflare, :bucket) %>
+  bucket: <%= ENV.fetch("CLOUDFLARE_R2_BUCKET", Rails.application.credentials.dig(:cloudflare, :bucket)) %>
   force_path_style: true
   request_checksum_calculation: "when_required"
   response_checksum_validation: "when_required"


### PR DESCRIPTION
Enable the use of Cloudflare R2 for Active Storage when the appropriate environment variables are set, falling back to local storage otherwise. This change enhances flexibility in storage configuration for development environments.