### PR TITLE
fix(kitchen): fix countdown deadline

### DIFF
--- a/app/assets/stylesheets/pages/kitchen/_index.scss
+++ b/app/assets/stylesheets/pages/kitchen/_index.scss
@@ -141,9 +141,15 @@
   padding: 0.5em;
   border: 0.2em solid var(--color-brown-500);
   border-radius: 0.5em;
+  text-align: center;
 
   span {
     font-weight: normal;
+  }
+
+  span#countdown-info {
+    font-size: 1.5rem;
+    cursor: pointer;
   }
 }
 

--- a/app/views/kitchen/index.html.erb
+++ b/app/views/kitchen/index.html.erb
@@ -7,8 +7,8 @@
     <%= render HeadingComponent.new(title: "Kitchen", tone: :blue, size: :full) %>
   </div>
 
-  <div class="kitchen-countdown" data-controller="countdown" data-countdown-date-value="2026-04-30T00:00:00-05:00">
-    <h1>Time remaining: <span data-countdown-target="display">Calculating...</span></h1>
+  <div class="kitchen-countdown" data-controller="countdown" data-countdown-date-value="2026-05-01T00:00:00-05:00">
+    <h1>Time remaining <span id="countdown-info">ⓘ</span>: <span data-countdown-target="display">Calculating...</span></h1>
   </div>
 
   <% if @show_and_tell_live %>
@@ -407,3 +407,7 @@
     <%= render KitchenHelpCardsComponent %>
   </div>
 </div>
+
+<%= render TooltipComponent.new(target_id: "countdown-info", position: :top) do %>
+  This is for the last day to ship projects — voting and payouts will continue, and the shop will also remain open for 1 week after the last payouts are given!
+<% end %>


### PR DESCRIPTION
Corrected deadline to midnight on May 1st in EST (since midnight is also the start of next day and that messed up the countdown :pf:). Also added a tooltip to clarify this is only the shipping deadline and payouts, voting and the shop will remain open.

<img width="1490" height="618" alt="image" src="https://github.com/user-attachments/assets/9eec61c9-fb9c-4053-b288-ea711f915252" />