### PR TITLE
update(platform): add flippers to creation of projects, comments, etc

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -54,6 +54,10 @@ class Api::V1::ProjectsController < Api::BaseController
   end
 
   def create
+    unless Flipper.enabled?(:create_projects, current_api_user)
+      return render json: { error: "Project creation is currently disabled" }, status: :forbidden
+    end
+
     @project = Project.new(project_params)
 
     ActiveRecord::Base.transaction do

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,6 +1,6 @@
 class CommentPolicy < ApplicationPolicy
   def create?
-    logged_in?
+    logged_in? && Flipper.enabled?(:create_comments, user)
   end
 
   def destroy?

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -8,11 +8,11 @@ class ProjectPolicy < ApplicationPolicy
     end
 
     def new?
-        logged_in?
+        logged_in? && Flipper.enabled?(:create_projects, user)
     end
 
     def create?
-        logged_in?
+        logged_in? && Flipper.enabled?(:create_projects, user)
     end
 
     def edit?
@@ -57,7 +57,7 @@ class ProjectPolicy < ApplicationPolicy
 
     # well, we shoudn't be doing this. but i think i goofed up a lil and authorize @devlog won't work without passing @project and Post::Devlog does not have @project
     def create_devlog?
-        member?
+        member? && Flipper.enabled?(:create_devlogs, user)
     end
 
     private

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -33,6 +33,15 @@ Rails.application.config.after_initialize do
     Flipper.add(:shipping) unless Flipper.exist?(:shipping)
     Flipper.add(:user_profiles) unless Flipper.exist?(:user_profiles)
     Flipper.add(:show_and_tell_live) unless Flipper.exist?(:show_and_tell_live)
+
+    # Creation kill-switches: enabled by default so existing behavior is preserved.
+    # Disable via Flipper UI to prevent users from creating these resources.
+    [ :create_projects, :create_comments, :create_devlogs ].each do |feature|
+      unless Flipper.exist?(feature)
+        Flipper.add(feature)
+        Flipper.enable(feature)
+      end
+    end
   rescue StandardError => e
     Rails.logger.warn "Could not initialize flipper: #{e.message}"
   end


### PR DESCRIPTION
This pr basically makes it so creating projects, comments are flippered. If the flipper is off nobody (including admins) can do such actions.