### PR TITLE
temporarily disable ysws_review_sync

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -124,11 +124,11 @@ production:
     concurrency: 1
     description: "Send daily shop order summary to Slack with backlog, assignments, and hang times"
 
-  ysws_review_sync:
-    class: YswsReviewSyncJob
-    schedule: every day at 9am America/New_York
-    concurrency: 1
-    description: "Sync completed YSWS reviews to Airtable with user PII"
+  # ysws_review_sync:
+  #   class: YswsReviewSyncJob
+  #   schedule: every day at 9am America/New_York
+  #   concurrency: 1
+  #   description: "Sync completed YSWS reviews to Airtable with user PII"
 
   shop_calculate_fulfillment_payouts:
     class: Shop::CalculateFulfillmentPayoutsJob


### PR DESCRIPTION
currently investigating a possible issue with the goi dash/reviews - temporarily disabling airtable syncing while investigating after talking with AVD and Eric