### PR TITLE
[codex] add shop close countdown

### DIFF
--- a/app/assets/stylesheets/pages/shop/_shop.scss
+++ b/app/assets/stylesheets/pages/shop/_shop.scss
@@ -483,6 +483,114 @@
   }
 }
 
+.shop-closure-banner {
+  margin: 0 auto 2rem;
+  max-width: 980px;
+  padding: 1.25rem 1.5rem;
+  border: 4px solid var(--color-red-400);
+  border-radius: 18px;
+  background: linear-gradient(135deg, #fff7ed 0%, #fde68a 100%);
+  box-shadow: 0 10px 24px rgba(120, 53, 15, 0.14);
+  text-align: left;
+
+  &__eyebrow {
+    margin: 0 0 0.5rem 0;
+    color: var(--color-red-500);
+    font-family: var(--font-family-subtitle);
+    font-size: 0.95rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  &__content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+
+  &__title {
+    margin: 0;
+    color: var(--color-brown-700);
+    font-family: var(--font-family-subtitle);
+    font-size: 2rem;
+    line-height: 1.05;
+  }
+
+  &__subtitle {
+    margin: 0.4rem 0 0;
+    color: var(--color-brown-500);
+    font-family: var(--font-family-text);
+    font-size: 1rem;
+  }
+
+  &__timer {
+    min-width: 240px;
+    padding: 0.9rem 1rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.78);
+    border: 2px solid rgba(146, 64, 14, 0.16);
+    text-align: center;
+  }
+
+  &__timer-label {
+    display: block;
+    color: var(--color-brown-500);
+    font-family: var(--font-family-text);
+    font-size: 0.95rem;
+  }
+
+  &__timer-value {
+    display: block;
+    margin-top: 0.15rem;
+    color: var(--color-red-500);
+    font-family: var(--font-family-subtitle);
+    font-size: 1.6rem;
+  }
+
+  @media (max-width: 800px) {
+    padding: 1rem 1.1rem;
+
+    &__content {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    &__title {
+      font-size: 1.6rem;
+    }
+
+    &__timer {
+      width: 100%;
+      min-width: 0;
+    }
+  }
+}
+
+.shop-closed-state {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 2rem;
+  border-radius: 18px;
+  background: rgba(255, 248, 235, 0.9);
+  border: 3px solid var(--color-brown-400);
+  box-shadow: 0 8px 18px rgba(77, 43, 50, 0.12);
+
+  &__title {
+    margin: 0;
+    color: var(--color-brown-700);
+    font-family: var(--font-family-subtitle);
+    font-size: 2rem;
+  }
+
+  &__copy {
+    margin: 0.75rem 0 0;
+    color: var(--color-brown-500);
+    font-family: var(--font-family-text);
+    font-size: 1.05rem;
+  }
+}
+
 .shop__recently-added {
   margin: 2rem 0;
   text-align: center;

--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -1,9 +1,10 @@
 class ShopController < ApplicationController
   skip_before_action :refresh_identity_on_portal_return, only: [ :index ]
   before_action :require_login, except: [ :index, :update_region ]
+  before_action :set_shop_availability_state, only: [ :index, :order, :create_order ]
+  before_action :ensure_shop_open!, only: [ :order, :create_order ]
 
   def index
-    @shop_open = Flipper.enabled?(:shop_open, current_user)
     @orders_enabled = Flipper.enabled?(:shop_orders, current_user)
     @user_region = user_region
     @body_class = "shop-page"
@@ -283,5 +284,18 @@ class ShopController < ApplicationController
     return tz_region if tz_region.present? && tz_region != "XX"
 
     "US"
+  end
+
+  def set_shop_availability_state
+    @shop_open = Flipper.enabled?(:shop_open, current_user)
+    @shop_closes_at = Shop::ClosureSchedule.closes_at
+    @shop_close_deadline_label = Shop::ClosureSchedule.deadline_label
+    @shop_countdown_active = @shop_open && Shop::ClosureSchedule.countdown_active?
+  end
+
+  def ensure_shop_open!
+    return if @shop_open
+
+    redirect_to shop_path, alert: "The shop is currently closed."
   end
 end

--- a/app/models/shop/closure_schedule.rb
+++ b/app/models/shop/closure_schedule.rb
@@ -1,0 +1,21 @@
+module Shop
+  module ClosureSchedule
+    TIMEZONE = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+    CLOSES_AT = TIMEZONE.local(2026, 5, 9, 0, 0, 0)
+    DEADLINE_LABEL = "Saturday, May 9 at 12:00 AM ET".freeze
+
+    module_function
+
+    def closes_at
+      CLOSES_AT
+    end
+
+    def deadline_label
+      DEADLINE_LABEL
+    end
+
+    def countdown_active?(reference_time = Time.current)
+      reference_time < closes_at
+    end
+  end
+end

--- a/app/views/shop/_closure_countdown.html.erb
+++ b/app/views/shop/_closure_countdown.html.erb
@@ -1,0 +1,13 @@
+<div class="shop-closure-banner" data-controller="countdown" data-countdown-date-value="<%= closes_at.iso8601 %>">
+  <p class="shop-closure-banner__eyebrow">Heads up</p>
+  <div class="shop-closure-banner__content">
+    <div>
+      <h2 class="shop-closure-banner__title">The shop closes <%= deadline_label %>.</h2>
+      <p class="shop-closure-banner__subtitle">Finish any orders before the flag flips off.</p>
+    </div>
+    <div class="shop-closure-banner__timer">
+      <span class="shop-closure-banner__timer-label">Closing in</span>
+      <span class="shop-closure-banner__timer-value" data-countdown-target="display">Loading...</span>
+    </div>
+  </div>
+</div>

--- a/app/views/shop/index.html.erb
+++ b/app/views/shop/index.html.erb
@@ -22,6 +22,10 @@
 <div class="shop" data-controller="shop" data-shop-user-region-value="<%= @user_region %>">
   <%= render HeadingComponent.new(title: "Shop", tone: :blue, size: :full) %>
 
+  <% if @shop_countdown_active %>
+    <%= render "shop/closure_countdown", closes_at: @shop_closes_at, deadline_label: @shop_close_deadline_label %>
+  <% end %>
+
   <div class="shop-goals" data-controller="shop-goals" data-shop-goals-balance-value="<%= @user_balance %>">
     <div class="shop-goals__container" data-shop-goals-target="container" style="display: none;">
       <h3 class="shop-goals__title"><%= inline_svg_tag "icons/star_fill.svg" %> My Goal Items</h3>
@@ -178,7 +182,18 @@
       </div>
     <% end %>
   <% else %>
-    <h2>The shop is not opened yet!</h2>
+    <div class="shop-closed-state">
+      <h2 class="shop-closed-state__title">The shop is closed right now.</h2>
+      <p class="shop-closed-state__copy">We&rsquo;ll reopen it once orders are available again.</p>
+      <% if current_user %>
+        <%= render ButtonComponent.new(
+          text: "View My Orders",
+          href: "/shop/my_orders",
+          color: :brown,
+          variant: :borderless
+        ) %>
+      <% end %>
+    </div>
   <% end %>
 </div>
 

--- a/app/views/shop/order.html.erb
+++ b/app/views/shop/order.html.erb
@@ -16,6 +16,9 @@
             </div>
         <% end %>
     </div>
+    <% if @shop_countdown_active %>
+        <%= render "shop/closure_countdown", closes_at: @shop_closes_at, deadline_label: @shop_close_deadline_label %>
+    <% end %>
     <div class="shop-order__content">
         <div class="shop-order__view"
          data-controller="customs-warning"

--- a/test/controllers/shop_controller_test.rb
+++ b/test/controllers/shop_controller_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class ShopControllerTest < ActionDispatch::IntegrationTest
+  include ActiveSupport::Testing::TimeHelpers
+
+  setup do
+    @user = users(:one)
+  end
+
+  teardown do
+    travel_back
+    Flipper.disable(:shop_open)
+  end
+
+  test "shop index shows the scheduled closure countdown while open" do
+    travel_to Time.utc(2026, 5, 6, 16, 0, 0) do
+      Flipper.enable(:shop_open)
+
+      get shop_path
+
+      assert_response :success
+      assert_includes response.body, "The shop closes Saturday, May 9 at 12:00 AM ET."
+      assert_includes response.body, %(data-countdown-date-value="2026-05-09T00:00:00-04:00")
+    end
+  end
+
+  test "shop order page redirects when the global shop flag is off" do
+    sign_in(@user)
+    Flipper.disable(:shop_open)
+
+    get shop_order_path(shop_item_id: 999_999)
+
+    assert_redirected_to shop_path
+    follow_redirect!
+    assert_includes response.body, "The shop is closed right now."
+  end
+
+  test "shop order creation redirects when the global shop flag is off" do
+    sign_in(@user)
+    Flipper.disable(:shop_open)
+
+    post shop_order_path, params: { shop_item_id: 999_999, quantity: 1 }
+
+    assert_redirected_to shop_path
+    assert_equal "The shop is currently closed.", flash[:alert]
+  end
+end


### PR DESCRIPTION
## What changed
- enforce the existing `shop_open` Flipper gate on direct shop order pages and order creation, not just the `/shop` listing
- add a shared countdown banner for the scheduled Saturday, May 9 at 12:00 AM ET shop close
- replace the old closed-shop copy with a clearer closed state and add focused controller coverage for the new behavior

## Why
The shop already hid the main listing when `shop_open` was off, but direct `/shop/order` URLs could still render and order creation was only gated by `shop_orders`. That meant the "global" close switch was incomplete. This tightens the close path and gives users a visible countdown before the Saturday shutdown.

## User impact
- users see a live close countdown on the shop and item order pages while the shop is still open
- once `shop_open` is flipped off globally, direct order pages redirect back to the closed shop instead of remaining reachable
- signed-in users still get a path to `My Orders` from the closed state

## Validation
- `ruby -c app/controllers/shop_controller.rb`
- `ruby -c app/models/shop/closure_schedule.rb`
- attempted `docker compose run --service-ports web bin/rails test test/controllers/shop_controller_test.rb` but the environment is still on the initial Docker image pull for Postgres, so the Rails test run has not completed yet
- attempted host-side `bin/rails test test/controllers/shop_controller_test.rb`, but this checkout expects the Dockerized Postgres on `127.0.0.1:5433`, so it cannot boot the test DB directly on the host
