### PR TITLE
feat(admin): add flipper to allow users to vote regardless of vote balance

### DIFF
--- a/app/policies/vote_policy.rb
+++ b/app/policies/vote_policy.rb
@@ -19,7 +19,7 @@ class VotePolicy < ApplicationPolicy
 
     raise Pundit::NotAuthorizedError, "Your voting has been locked temporarily. Please contact @Fraud Squad for more information." if user.voting_locked?
     raise Pundit::NotAuthorizedError, "You must have shipped at least one project to vote." unless user.has_shipped?
-    raise Pundit::NotAuthorizedError, "You've used all available votes for now. Ship again to unlock more votes." unless user.vote_balance < 0
+    raise Pundit::NotAuthorizedError, "You've used all available votes for now. Ship again to unlock more votes." unless user.vote_balance < 0 || Flipper.enabled?(:vote_balance_override, user)
     raise Pundit::NotAuthorizedError, "Voting is currently disabled." unless Flipper.enabled?(:voting, user)
 
     true

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -348,6 +348,7 @@
           { key: :"git_commit_2025-12-25", label: "Git Commit" },
           { key: :kitchen_comic, label: "Kitchen Comic" },
           { key: :voting, label: "Voting" },
+          { key: :vote_balance_override, label: "Allow voting" },
           { key: :christmas_theme, label: "Christmas" },
           { key: :grant_cookies, label: "Grant Cookies" }
         ]


### PR DESCRIPTION
Gives admins a flipper feature on the admin user page that bypasses the vote-balance check in `vote_policy.rb`!