### PR TITLE
fix(vote-policy): allow vote balance override flipper users to vote without shipping

### DIFF
--- a/app/policies/vote_policy.rb
+++ b/app/policies/vote_policy.rb
@@ -18,7 +18,7 @@ class VotePolicy < ApplicationPolicy
     raise Pundit::NotAuthorizedError, "You are not authorized to perform this action." unless user&.verification_verified?
 
     raise Pundit::NotAuthorizedError, "Your voting has been locked temporarily. Please contact @Fraud Squad for more information." if user.voting_locked?
-    raise Pundit::NotAuthorizedError, "You must have shipped at least one project to vote." unless user.has_shipped?
+    raise Pundit::NotAuthorizedError, "You must have shipped at least one project to vote." unless user.has_shipped? || Flipper.enabled?(:vote_balance_override, user)
     raise Pundit::NotAuthorizedError, "You've used all available votes for now. Ship again to unlock more votes." unless user.vote_balance < 0 || Flipper.enabled?(:vote_balance_override, user)
     raise Pundit::NotAuthorizedError, "Voting is currently disabled." unless Flipper.enabled?(:voting, user)
 


### PR DESCRIPTION
Very small change requested by @MMK21Hub! Allows users with the `vote_balance_override` flipper set to true to vote even if they have not shipped anything.