### PR TITLE
Remove email signup CTA from closed Flavortown landing hero

### DIFF
--- a/app/views/landing/sections/_hero.html.erb
+++ b/app/views/landing/sections/_hero.html.erb
@@ -68,24 +68,12 @@
       <% if @landing_variant == "challenger" %>
         Ship a space-related project by April 30th! Submit it to this sidequest to qualify for space-themed prizes in the shop.
       <% else %>
-        Code personal projects. Win free prizes.
+        Flavortown has ended.
       <% end %>
     </h3>
 
     <div class="rsvp-form">
-      <%= form_with url: submit_email_path, method: :post, local: true do |form| %>
-        <div class="input-red">
-          <div>
-            <%= inline_svg_tag "icons/mail.svg" %>
-            <%= form.email_field :email, placeholder: "Enter your email...", autocomplete: "off", required: true %>
-          </div>
-        </div>
-
-        <%= form.button type: "submit", class: "btn btn--red btn--striped" do %>
-          <div>Get Started</div>
-        <% end %>
-      <% end %>
-      <%= button_to "or, sign back in", "/auth/hack_club", method: :post, form_class: "sign-back-in-link", class: "link-btn" %>
+      <%= button_to "Sign in", "/auth/hack_club", method: :post, form_class: "sign-back-in-link", class: "link-btn" %>
       <% if Rails.env.development? && current_user.blank? %>
         <%= button_to "dev login",
                       "/dev_login",
@@ -100,8 +88,6 @@
     <% else %>
       <h4>Ages 13-18. <u>Dec 22</u> to <u>April 30</u>.</h4>
     <% end %>
-    <h5>19 or older? Get the same prizes by <a href="https://docs.google.com/document/d/e/2PACX-1vRxWWFVm0pr4042oYljyPAdwb5pH7sdRiwfPw4i01PVs436MfiAFJnKtGoyWwRkXIlB6PlIaVyTQbvO/pub" target="_blank">referring teens</a>.</h5>
-
     <%= image_tag image_url("icons/chevrons-red-down.svg"), class: "carat", size: 48, alt: "" %>
   </div>
 


### PR DESCRIPTION
## Summary
Follow-up to #2297. Now that Flavortown has ended, the landing hero should no longer recruit signups.

## Changes
- app/views/landing/sections/_hero.html.erb: hero tagline now reads 'Flavortown has ended.', removed the main email signup form (and Get Started button), and dropped the active refer-teens-for-prizes line. The sign-in link is kept (relabeled Sign in) so existing participants can still log in.

?? Generated with [Claude Code](https://claude.com/claude-code)